### PR TITLE
fix(touch): incorrect logging in accuracy macro

### DIFF
--- a/src/cartographer/macros/touch.py
+++ b/src/cartographer/macros/touch.py
@@ -51,7 +51,7 @@ class TouchAccuracyMacro(Macro[MacroParams]):
         position = self._toolhead.get_position()
 
         logger.info(
-            "TOUCH_ACCURACY at X:%.3f Y:%.3f Z:%.3f (samples=%d retract=%.3f speed=%.1f lift_speed=%.1f)",
+            "TOUCH_ACCURACY at X:%.3f Y:%.3f Z:%.3f (samples=%d retract=%.3f lift_speed=%.1f)",
             position.x,
             position.y,
             position.z,


### PR DESCRIPTION
Just missed a formatting parameter when removing the option to control probing speed.