### PR TITLE
fix(touch): wait for moves before probe

### DIFF
--- a/src/cartographer/macros/touch.py
+++ b/src/cartographer/macros/touch.py
@@ -175,6 +175,7 @@ class TouchCalibrateMacro(Macro[MacroParams]):
             y=self._config.zero_reference_position[1],
             speed=self._probe.config.move_speed,
         )
+        self._toolhead.wait_moves()
 
         best_threshold = self._find_best_threshold(threshold_start, threshold_max, speed)
 


### PR DESCRIPTION
Ocassionally klipper would complain that the probe triggered before it was set to move.