### PR TITLE
fix(axis_twist_compensation): invert result calculation

### DIFF
--- a/src/cartographer/macros/axis_twist_compensation.py
+++ b/src/cartographer/macros/axis_twist_compensation.py
@@ -79,7 +79,7 @@ class AxisTwistCompensationMacro(Macro[MacroParams]):
             results.append(result)
 
         avg = float(np.mean(results))
-        results = [offset - avg for offset in results]
+        results = [avg - x for x in results]
 
         self.helper.save_compensations(axis, calibration.start, calibration.end, results)
         logger.info("""


### PR DESCRIPTION
We are implementing [this](https://github.com/Klipper3d/klipper/blob/bfda326c2403bf96ff909140dcaf26509476fb3c/klippy/extras/axis_twist_compensation.py#L311-L313) klipper code.
The comment does not match the calculation.