### PR TITLE
fix(mcu): warn when no trapq instead of erroring

### DIFF
--- a/src/cartographer/adapters/klipper/mcu/mcu.py
+++ b/src/cartographer/adapters/klipper/mcu/mcu.py
@@ -193,8 +193,8 @@ class KlipperCartographerMcu(Mcu, KlipperStreamMcu):
     def get_requested_position(self, time: float) -> tuple[Position | None, float | None]:
         trapq = self.motion_report.trapqs.get("toolhead")
         if trapq is None:
-            msg = "No dump trapq for toolhead"
-            raise RuntimeError(msg)
+            logger.warning("No dump trapq for toolhead, cannot get position at time %.3f", time)
+            return None, None
         position, velocity = trapq.get_trapq_position(time)
         if position is None:
             return None, velocity


### PR DESCRIPTION
This will remove the errors and simply log a warning if we cannot get the position for a sample.
Cleans this up.
![image](https://github.com/user-attachments/assets/d403898e-fe6d-4990-9d40-f39b3267d708)
