### PR TITLE
fix(touch): always force z position for calibrate and home

### DIFF
--- a/src/cartographer/macros/utils.py
+++ b/src/cartographer/macros/utils.py
@@ -1,10 +1,11 @@
 from __future__ import annotations
 
+from contextlib import contextmanager
 from enum import Enum
-from typing import TYPE_CHECKING, Iterable, TypeVar
+from typing import TYPE_CHECKING, Iterable, Iterator, TypeVar
 
 if TYPE_CHECKING:
-    from cartographer.interfaces.printer import MacroParams
+    from cartographer.interfaces.printer import MacroParams, Toolhead
 
 T = TypeVar("T", bound=Enum)
 
@@ -61,3 +62,22 @@ def get_float_tuple(params: MacroParams, option: str, default: tuple[float, floa
         raise ValueError(msg)
 
     return (float(parts[0]), float(parts[1]))
+
+
+@contextmanager
+def forced_z(toolhead: Toolhead) -> Iterator[None]:
+    """
+    Context manager that temporarily sets a forced Z position for homing operations.
+
+    Parameters
+    ----------
+    toolhead : Toolhead
+        The toolhead instance to manage Z positioning for.
+    """
+    _, z_max = toolhead.get_axis_limits("z")
+    toolhead.set_z_position(z=z_max - 10)
+
+    try:
+        yield
+    finally:
+        toolhead.clear_z_homing_state()

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -51,6 +51,7 @@ def toolhead(mocker: MockerFixture) -> Toolhead:
         homing_state.is_homing_z = mocker.Mock(return_value=True)
         endstop.on_home_end(homing_state)
 
+    mock.get_axis_limits = mocker.Mock(return_value=(0, 100))
     mock.get_position = get_position
     mock.get_extruder_temperature = get_extruder_temperature
     mock.z_home_end = z_home_end

--- a/tests/macros/test_touch.py
+++ b/tests/macros/test_touch.py
@@ -151,7 +151,7 @@ def test_touch_home_macro(
 
     macro.run(params)
 
-    assert set_z_position_spy.mock_calls == [mocker.call(expected)]
+    assert set_z_position_spy.mock_calls == [mocker.call(z=mocker.ANY), mocker.call(expected)]
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
fixes #361 

We always force a z position and clear it for calibration and homing, as we can not be sure that the z homing we receive are actually correct. Thus this would be less confusing for our users.
This is especially the case for those using `homing_override` where they set a z position to 0. That would almost always interfere with a touch home or touch calibrate. They would be required to manually call `SET_KINEMATIC_POSITION Z=<max-10>` which requires that they enable `force_move` and is more frustrating to document..