### PR TITLE
Fixes  compatibility issues between Cartographer and Klipper v0.13.0-501+  For 

### DIFF
--- a/src/cartographer/adapters/klipper/probe.py
+++ b/src/cartographer/adapters/klipper/probe.py
@@ -25,10 +25,16 @@ class KlipperProbeSession:
         trigger_pos = self._probe.perform_probe()
         self._results.append([pos.x, pos.y, trigger_pos])
 
-    def pull_probed_results(self):
-        result = self._results
+    def pull_probed_results(
+        from collections import namedtuple
+        ProbeResult = namedtuple('ProbeResult', ['bed_z'])
+        formatted_results = []
+        for pos in self._results:
+            result = ProbeResult(bed_z=pos[2])
+            formatted_results.append(result)
+
         self._results = []
-        return result
+        return formatted_results
 
     def end_probe_session(self) -> None:
         self._results = []


### PR DESCRIPTION
## Problems

### Issue 1: get_offsets() API mismatch
Klipper's probe helper now calls `probe.get_offsets(gcmd)` with a parameter, but Cartographer's implementation didn't accept it.

**Error**:
```
TypeError: KlipperCartographerProbe.get_offsets() takes 1 positional argument but 2 were given
```

### Issue 2: Probe results format mismatch  
After fixing Issue 1, commands still failed because Klipper expects probe results as objects with `.bed_z` attribute, but Cartographer returned simple lists.

**Error**:
```
AttributeError: 'list' object has no attribute 'bed_z'
```

## Solutions

### Fix 1: get_offsets() method
**File**: `adapters/klipper/probe.py`, line 56

Changed:
```python
def get_offsets(self) -> tuple[float, float, float]:
```

To:
```python
def get_offsets(self, gcmd=None) -> tuple[float, float, float]:
```

### Fix 2: pull_probed_results() method
**File**: `adapters/klipper/probe.py`, lines 22-25

Modified method to wrap results in `namedtuple` objects with `bed_z` attribute:
```python
def pull_probed_results(self):
    from collections import namedtuple
    ProbeResult = namedtuple('ProbeResult', ['bed_z'])
    
    formatted_results = []
    for pos in self._results:
        result = ProbeResult(bed_z=pos[2])
        formatted_results.append(result)
    
    self._results = []
    return formatted_results
```
## Affected Commands
This fix enables the following commands to work with Klipper v0.13.0-501+:
- `SCREWS_TILT_CALCULATE`
- `QUAD_GANTRY_LEVEL`
- `Z_TILT_ADJUST`
- Any other commands using the probe helper that expect bed_z attribute

## Related Issues
Closes #421