### PR TITLE
fix(klipper): new probe interface compatibility

### DIFF
--- a/src/cartographer/adapters/klipper/axis_twist_compensation.py
+++ b/src/cartographer/adapters/klipper/axis_twist_compensation.py
@@ -1,3 +1,4 @@
+from extras import manual_probe
 from typing_extensions import override
 
 from cartographer.adapters.klipper_like.axis_twist_compensation import KlipperLikeAxisTwistCompensationAdapter
@@ -7,24 +8,15 @@ class KlipperAxisTwistCompensationAdapter(KlipperLikeAxisTwistCompensationAdapte
     @override
     def get_z_compensation_value(self, *, x: float, y: float) -> float:
         # Support both old and new Klipper versions
-        import importlib
-        try:
-            manual_probe = importlib.import_module(".manual_probe", "extras")
-            # Check if ProbeResult exists (Klipper >= v0.13.0-465, introduced Dec 2025)
-            if hasattr(manual_probe, 'ProbeResult'):
-                # New Klipper: send ProbeResult object
-                probe_result = manual_probe.ProbeResult(x, y, 0.0, x, y, 0.0)
-                pos_list = [probe_result]
-                self.printer.send_event("probe:update_results", pos_list)
-                return pos_list[0].bed_z
-            else:
-                # Old Klipper: send plain list
-                pos = [x, y, 0]
-                self.printer.send_event("probe:update_results", pos)
-                return pos[2]
-        except (ImportError, AttributeError):
-            # Fallback for very old versions
+        # Check if ProbeResult exists (Klipper >= v0.13.0-465, introduced Dec 2025)
+        if not hasattr(manual_probe, "ProbeResult"):
+            # Old Klipper: send plain list
             pos = [x, y, 0]
             self.printer.send_event("probe:update_results", pos)
             return pos[2]
 
+        # New Klipper: send ProbeResult object
+        probe_result = manual_probe.ProbeResult(x, y, 0.0, x, y, 0.0)
+        pos_list = [probe_result]
+        self.printer.send_event("probe:update_results", pos_list)
+        return pos_list[0].bed_z

--- a/typings/extras/manual_probe.pyi
+++ b/typings/extras/manual_probe.pyi
@@ -1,5 +1,6 @@
 # Helper script to determine a Z height
 from collections.abc import Callable
+from typing import NamedTuple
 
 from gcode import GCodeCommand
 from klippy import Printer
@@ -15,3 +16,20 @@ class ManualProbeHelper:
         gcmd: GCodeCommand,
         finalize_callback: Callable[[_Pos | None], None],
     ) -> None: ...
+
+class ProbeResult(NamedTuple):
+    """
+    WARNING: This class may not exist at runtime depending on klipper version.
+    Always check with hasattr() before use.
+
+    Example:
+        if hasattr(manual_probe, 'ProbeResult'):
+            result = manual_probe.ProbeResult(...)
+    """
+
+    bed_x: float
+    bed_y: float
+    bed_z: float
+    test_x: float
+    test_y: float
+    test_z: float

--- a/typings/klippy.pyi
+++ b/typings/klippy.pyi
@@ -10,6 +10,7 @@ from extras.bed_mesh import BedMesh
 from extras.exclude_object import ExcludeObject
 from extras.heaters import PrinterHeaters
 from extras.homing import Homing, HomingMove, PrinterHoming
+from extras.manual_probe import ProbeResult
 from extras.motion_report import PrinterMotionReport
 from gcode import CommandError, GCodeDispatch
 from gcode_move import GCodeMove
@@ -107,7 +108,7 @@ class Printer:
     @overload
     def lookup_object(self, name: Literal["cartographer"]) -> PrinterCartographer: ...
     @overload
-    def send_event(self, event: Literal["probe:update_results"], pos: list[float]) -> None: ...
+    def send_event(self, event: Literal["probe:update_results"], pos: list[float] | list[ProbeResult]) -> None: ...
     @overload
     def send_event(
         self, event: Literal["homing:home_rails_end"], homing: Homing, rails: list[GenericPrinterRail]


### PR DESCRIPTION
## Problem

Recent Klipper changes (December 2025 - January 2026) modified the probe interface, breaking compatibility with the Cartographer plugin. This caused failures in several critical leveling and probing operations.

### Issues Fixed

#### 1. TypeError: get_offsets() method signature mismatch
**Error:**
```
TypeError: KlipperCartographerProbe.get_offsets() takes 1 positional argument but 2 were given
```

**Root Cause:** Klipper commit [2956c1e22](https://github.com/Klipper3d/klipper/commit/2956c1e22) (Jan 22, 2026) changed the probe interface to pass an optional `gcmd` parameter to `get_offsets()`.

**Affected Commands:**
- `Z_TILT_ADJUST`
- `QUAD_GANTRY_LEVEL` (see issue #421)
- `BED_MESH_CALIBRATE`

#### 2. AttributeError: ProbeResult return type mismatch
**Error:**
```
AttributeError: 'list' object has no attribute 'bed_z'
```

**Root Cause:** Klipper commits [9ccb4d96e](https://github.com/Klipper3d/klipper/commit/9ccb4d96e) (Dec 20, 2025) and [2e0c2262e](https://github.com/Klipper3d/klipper/commit/2e0c2262e) (Dec 21, 2025) introduced the `ProbeResult` namedtuple to replace plain lists for probe results. The plugin was still returning `[[x, y, z], ...]` instead of `ProbeResult` objects.

**Affected Code:**
- `z_tilt.py` - accesses `pos.bed_z`
- `bed_mesh.py` - accesses `p.bed_x`, `p.bed_y`, `p.bed_z`
- `quad_gantry_level.py` - works with both lists and ProbeResult due to indexing

#### 3. AttributeError in axis_twist_compensation
**Error:**
```
AttributeError: 'float' object has no attribute 'bed_x'
```

**Root Cause:** The `probe:update_results` event was sending plain lists which are incompatible with new Klipper versions expecting ProbeResult objects.

---

## Solution

All fixes include **full backward compatibility** with older Klipper versions (pre-December 2025).

### Changes Made

#### 1. Fixed `get_offsets()` signature (probe.py)
Changed from:
```python
def get_offsets(self):
```
To:
```python
def get_offsets(self, gcmd=None):
```
The `gcmd` parameter is optional, maintaining compatibility with both old and new Klipper.

#### 2. Fixed `pull_probed_results()` return type (probe.py)
Modified to detect Klipper version and return appropriate format:
- **New Klipper (>= v0.13.0-465)**: Returns `ProbeResult` namedtuples
- **Old Klipper (< v0.13.0-465)**: Returns plain lists `[[x, y, z], ...]`

Uses runtime detection:
```python
try:
    from extras.manual_probe import ProbeResult
    has_probe_result = True
except ImportError:
    has_probe_result = False
```

#### 3. Fixed axis_twist_compensation event data
Updated `get_z_compensation_value()` to detect Klipper version and send appropriate data format in `probe:update_results` events.

---

## Backward Compatibility

✅ **Tested with both old and new Klipper versions:**

### Old Klipper (dc622f4a - Dec 19, 2025, before ProbeResult)
- ✅ `Z_TILT_ADJUST`: Success
- ✅ `BED_MESH_CALIBRATE`: Success

### New Klipper (7f822f3a - Latest, with ProbeResult)
- ✅ `Z_TILT_ADJUST`: Success
- ✅ `BED_MESH_CALIBRATE`: Success
- ✅ `CARTOGRAPHER_TOUCH_HOME`: Success

---

## Testing

### Tested Commands
- `G28` (homing)
- `Z_TILT_ADJUST` (4-point leveling)
- `BED_MESH_CALIBRATE` (13x13 adaptive mesh, 169 points)
- `CARTOGRAPHER_TOUCH_HOME`
- Active print with mesh compensation

### ⚠️ QUAD_GANTRY_LEVEL Not Tested
**I cannot test `QUAD_GANTRY_LEVEL` as my printer hardware does not support it.** However, the fix is identical to the `Z_TILT_ADJUST` fix, and issue #421 reports the exact same error signature.

### How to Test
1. **With new Klipper (>= Dec 2025):**
   ```
   G28
   Z_TILT_ADJUST
   BED_MESH_CALIBRATE
   QUAD_GANTRY_LEVEL  # if your hardware supports it
   ```

2. **With old Klipper (< Dec 2025):**
   Roll back to commit before `9ccb4d96e` and test the same commands.

All commands should complete successfully without errors.

---

## Related Issues
Fixes #421

## Klipper Version Compatibility
- ✅ Klipper < v0.13.0-465 (before Dec 20, 2025)
- ✅ Klipper >= v0.13.0-465 (Dec 20, 2025 and later)

---

## Files Changed
- `src/cartographer/adapters/klipper/probe.py`
- `src/cartographer/adapters/klipper/axis_twist_compensation.py`