### PR TITLE
feat: auto-generate configuration reference docs

### DIFF
--- a/.github/workflows/update-docs.yml
+++ b/.github/workflows/update-docs.yml
@@ -1,0 +1,54 @@
+name: Update Configuration Docs
+
+on:
+  release:
+    types: [published]
+
+jobs:
+  update-docs:
+    if: ${{ !github.event.release.prerelease }}
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout plugin
+        uses: actions/checkout@v4
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+
+      - name: Install plugin
+        run: pip install -e .
+
+      - name: Generate docs
+        run: python -m cartographer.config.docs > configuration-reference.md
+
+      - name: Generate GitHub App token
+        id: app-token
+        uses: actions/create-github-app-token@v1
+        with:
+          app-id: ${{ secrets.DOCS_APP_ID }}
+          private-key: ${{ secrets.DOCS_APP_PRIVATE_KEY }}
+          owner: Cartographer3D
+          repositories: docs
+
+      - name: Checkout docs repo
+        uses: actions/checkout@v4
+        with:
+          repository: Cartographer3D/docs
+          token: ${{ steps.app-token.outputs.token }}
+          path: docs-repo
+
+      - name: Update docs
+        run: |
+          cp configuration-reference.md docs-repo/cartographer-probe/reference/configuration-reference.md
+
+      - name: Commit and push
+        working-directory: docs-repo
+        run: |
+          git config user.name "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+          git add cartographer-probe/reference/configuration-reference.md
+          git diff --cached --quiet && echo "No changes to commit" && exit 0
+          git commit -m "docs: update configuration reference for ${{ github.event.release.tag_name }}"
+          git push

--- a/src/cartographer/config/docs.py
+++ b/src/cartographer/config/docs.py
@@ -1,0 +1,109 @@
+"""Generate Klipper-style configuration reference documentation from option() fields.
+
+Usage:
+    python -m cartographer.config.docs > configuration-reference.md
+"""
+
+from __future__ import annotations
+
+import sys
+from enum import Enum
+
+from cartographer.config.fields import OptionInfo, get_all_options
+from cartographer.interfaces.configuration import (
+    BedMeshConfig,
+    CoilConfiguration,
+    GeneralConfig,
+    ScanConfig,
+    ScanModelConfiguration,
+    TouchConfig,
+    TouchModelConfiguration,
+)
+
+# Config sections in the order they should appear in docs.
+# (section_header, klipper_section_name, dataclass)
+SECTIONS: list[tuple[str, str, type]] = [
+    ("General", "cartographer", GeneralConfig),
+    ("Scan", "cartographer scan", ScanConfig),
+    ("Touch", "cartographer touch", TouchConfig),
+    ("Bed Mesh", "bed_mesh", BedMeshConfig),
+    ("Coil", "cartographer coil", CoilConfiguration),
+    ("Scan Model", "cartographer scan_model <name>", ScanModelConfiguration),
+    ("Touch Model", "cartographer touch_model <name>", TouchModelConfiguration),
+]
+
+
+def _format_default(value: object) -> str:
+    """Format a default value for display in docs."""
+    if isinstance(value, bool):
+        return "True" if value else "False"
+    if isinstance(value, Enum):
+        return f"'{value.value}'"
+    if isinstance(value, str):
+        return f"'{value}'"
+    return str(value)
+
+
+def _format_option(opt: OptionInfo) -> str:
+    """Format a single option as a Klipper-style config reference block."""
+    lines: list[str] = []
+
+    # Description
+    if opt.description:
+        lines.append(f"#   {opt.description}")
+
+    # Constraints
+    constraints: list[str] = []
+    if opt.min is not None:
+        constraints.append(f"minimum: {opt.min}")
+    if opt.max is not None:
+        constraints.append(f"maximum: {opt.max}")
+    if constraints:
+        lines.append(f"#   Constraints: {', '.join(constraints)}")
+
+    # Allowed values (Enum choices)
+    if opt.choices:
+        lines.append(f"#   Allowed values: {', '.join(opt.choices)}")
+
+    # The option line itself
+    if opt.required:
+        lines.append(f"{opt.name}:")
+    elif opt.has_default:
+        lines.append(f"#{opt.name}: {_format_default(opt.default)}")
+    else:
+        lines.append(f"#{opt.name}:")
+
+    return "\n".join(lines)
+
+
+def generate_docs() -> str:
+    """Generate full configuration reference as a markdown string."""
+    parts: list[str] = []
+
+    parts.append("---")
+    parts.append("description: Auto-generated from plugin source.")
+    parts.append("---\n")
+    parts.append("# Configuration Reference\n")
+
+    for section_header, section_name, cls in SECTIONS:
+        options = get_all_options(cls)
+        if not options:
+            continue
+
+        parts.append(f"## {section_header}\n")
+        parts.append(f"```ini\n[{section_name}]")
+
+        for opt in options:
+            parts.append(_format_option(opt))
+
+        parts.append("```\n")
+
+    return "\n".join(parts)
+
+
+def main() -> None:
+    _ = sys.stdout.write(generate_docs())
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary

- Adds a `docs.py` script (`python -m cartographer.config.docs`) that introspects all `option()` fields from the config dataclasses and generates a Klipper-style configuration reference in Markdown
- Adds `OptionInfo` dataclass and `get_all_options()` to `fields.py` for programmatic access to option metadata (name, type, description, default, constraints, enum choices)
- Adds a GitHub Action (`update-docs.yml`) that runs on pushes to `main` when config-related files change, generates the docs, and commits the result to `Cartographer3D/docs` via a GitHub App token

## Details

- Fields with `description=None` are excluded from docs (internal fields)
- Enum choices are auto-detected and listed
- Constraints (min/max) are included when present
- Required fields render as `option_name:`, optional fields as `#option_name: <default>`
- The workflow uses `DOCS_APP_ID` and `DOCS_APP_PRIVATE_KEY` secrets to authenticate against the docs repo