### PR TITLE
chore(ci): use uv instead of pip in docs workflow

### DIFF
--- a/.github/workflows/update-docs.yml
+++ b/.github/workflows/update-docs.yml
@@ -12,16 +12,13 @@ jobs:
       - name: Checkout plugin
         uses: actions/checkout@v4
 
-      - name: Set up Python
-        uses: actions/setup-python@v5
+      - name: Set up uv
+        uses: astral-sh/setup-uv@v6
         with:
-          python-version: "3.12"
-
-      - name: Install plugin
-        run: pip install -e .
+          enable-cache: true
 
       - name: Generate docs
-        run: python -m cartographer.config.docs > configuration-reference.md
+        run: uv run python -m cartographer.config.docs > configuration-reference.md
 
       - name: Generate GitHub App token
         id: app-token


### PR DESCRIPTION
## Summary

- Replace `setup-python` + `pip install -e .` with `astral-sh/setup-uv` + `uv run` in the docs generation workflow, matching how `integration.yml` runs.