### PR TITLE
ci: replace hatch CLI with uv build in delivery workflow

### DIFF
--- a/.github/workflows/delivery.yml
+++ b/.github/workflows/delivery.yml
@@ -18,7 +18,10 @@ jobs:
         with:
           enable-cache: true
       - name: Build
-        run: uvx hatch build
+        run: uv build
+        env:
+          GIT_VERSION: ${{ github.ref_name }}
+          COMMIT_SHA: ${{ github.sha }}
       - name: Store the distribution packages
         uses: actions/upload-artifact@v4
         with:


### PR DESCRIPTION
## Summary

- Replace `uvx hatch build` with `uv build` in the delivery workflow, eliminating the `hatch` CLI (and its `virtualenv` dependency) from the build pipeline
- Add `COMMIT_SHA` / `GIT_VERSION` env var fallbacks to `hatch_build.py` so git metadata is available when building from sdist in an isolated directory
- Fail loudly in CI (`GITHUB_ACTIONS=true`) if git metadata is missing, preventing silent empty releases

## Context

[`virtualenv` v21.0.0](https://virtualenv.pypa.io/en/stable/changelog.html#v21-0-0-2026-02-25) (released 2026-02-25) extracted its Python discovery logic into a standalone package, breaking `hatch`'s virtual environment plugin ([pypa/hatch#2193](https://github.com/pypa/hatch/issues/2193)). This caused the delivery workflow to fail with:

```
Environment `hatch-build` is incompatible: module 'virtualenv.discovery.builtin' has no attribute 'propose_interpreters'
```

Rather than pinning `virtualenv<21` as a workaround, this PR removes the dependency entirely by using `uv build`, which invokes `hatchling` (the build backend) directly — no `virtualenv` needed.

## Changes

### `hatch_build.py`
- `get_commit_sha()` and `retrieve_git_version()` now fall back to `COMMIT_SHA` and `GIT_VERSION` env vars when git commands fail
- Added `_is_ci()` guard that raises `RuntimeError` if git metadata is missing in GitHub Actions

### `.github/workflows/delivery.yml`
- Replaced `uvx --with 'virtualenv<21' hatch build` → `uv build`
- Passes `GIT_VERSION` and `COMMIT_SHA` from GitHub Actions context

## Testing

Verified locally that:
- `uv build` with env vars produces identical wheel contents to `uvx hatch build`
- `GITHUB_ACTIONS=true` without env vars → build fails with clear error
- `GITHUB_ACTIONS=true` with env vars → build succeeds with correct metadata
- Local build (no `GITHUB_ACTIONS`) → works as before via git commands