### PR TITLE
feat(touch): add optimization phase to calibration with z_limit safety bound

### DIFF
--- a/src/cartographer/adapters/klipper_like/toolhead.py
+++ b/src/cartographer/adapters/klipper_like/toolhead.py
@@ -105,13 +105,13 @@ class KlipperLikeToolhead(Toolhead, ABC):
 
     @override
     @reraise_from_klipper
-    def z_probing_move(self, endstop: Endstop, *, speed: float) -> float:
+    def z_probing_move(self, endstop: Endstop, *, speed: float, z_limit: float | None = None) -> float:
         klipper_endstop = KlipperEndstop(self.mcu, endstop)
         self.wait_moves()
         z_min, _ = self.get_axis_limits("z")
 
         pos = self.toolhead.get_position()[:]
-        pos[2] = z_min
+        pos[2] = max(z_limit, z_min) if z_limit is not None else z_min
 
         epos = self.printer.lookup_object("homing").probing_move(klipper_endstop, pos, speed)
         return epos[2]

--- a/src/cartographer/interfaces/printer.py
+++ b/src/cartographer/interfaces/printer.py
@@ -179,8 +179,11 @@ class Toolhead(Protocol):
         """Returns currently applied gcode offset for the z axis."""
         ...
 
-    def z_probing_move(self, endstop: Endstop, *, speed: float) -> float:
-        """Starts probing move towards the given endstop."""
+    def z_probing_move(self, endstop: Endstop, *, speed: float, z_limit: float | None = None) -> float:
+        """Starts probing move towards the given endstop.
+
+        If z_limit is provided, the probe will not travel below that Z position.
+        """
         ...
 
     def z_home_end(self, endstop: Endstop) -> None:

--- a/src/cartographer/macros/touch/calibrate.py
+++ b/src/cartographer/macros/touch/calibrate.py
@@ -107,8 +107,33 @@ class CalibrationProbe(Protocol):
         """Update the active threshold."""
         ...
 
-    def perform_touch_probe(self) -> float:
+    def perform_touch_probe(self, *, z_limit: float | None = None) -> float:
         """Perform one complete touch probe sequence."""
+        ...
+
+
+@runtime_checkable
+class Screener(Protocol):
+    """Protocol for threshold screening operations."""
+
+    def screen(self, threshold: int, sample_count: int) -> ScreeningResult | None:
+        """Quick screen a threshold. Returns None on probe trigger error."""
+        ...
+
+
+@runtime_checkable
+class Verifier(Protocol):
+    """Protocol for threshold verification operations."""
+
+    def verify(
+        self,
+        threshold: int,
+        max_verify_range: float,
+        sample_count: int,
+        *,
+        z_limit: float | None = None,
+    ) -> VerificationResult | None:
+        """Verify a threshold with multiple touch probes. Returns None on failure."""
         ...
 
 
@@ -158,6 +183,8 @@ class ThresholdVerifier:
         threshold: int,
         max_verify_range: float,
         sample_count: int,
+        *,
+        z_limit: float | None = None,
     ) -> VerificationResult | None:
         """
         Verify threshold by running actual touch probe sequences.
@@ -179,7 +206,7 @@ class ThresholdVerifier:
 
         for attempt in range(sample_count):
             try:
-                median = self._probe.perform_touch_probe()
+                median = self._probe.perform_touch_probe(z_limit=z_limit)
                 medians.append(median)
                 logger.debug(
                     "Verification sample %d/%d: median=%.4fmm",
@@ -332,10 +359,47 @@ class TouchCalibrateMacro(Macro):
         )
         self._toolhead.wait_moves()
 
+    def _try_threshold(
+        self,
+        screener: Screener,
+        verifier: Verifier,
+        threshold: int,
+        screening_samples: int,
+        sample_range: float,
+        max_verify_range: float,
+        verification_samples: int,
+        *,
+        z_limit: float | None = None,
+    ) -> tuple[VerificationResult | None, int]:
+        """
+        Screen and verify a single threshold candidate.
+
+        Returns (result, step) where result is the VerificationResult
+        if both screening and verification succeeded, or None if either
+        phase failed. step is the recommended threshold increment.
+        """
+        screening = screener.screen(threshold, screening_samples)
+
+        if screening is None:
+            return None, calculate_step(threshold, None, sample_range)
+
+        self._log_screening_result(screening, sample_range)
+
+        if not screening.passed(sample_range):
+            return None, calculate_step(threshold, screening.best_range, sample_range)
+
+        verification = verifier.verify(threshold, max_verify_range, verification_samples, z_limit=z_limit)
+
+        if verification is None:
+            return None, calculate_step(threshold, None, sample_range)
+
+        self._log_verification_result(verification, max_verify_range)
+        return verification, calculate_step(threshold, verification.median_range, sample_range)
+
     def _find_threshold(
         self,
-        screener: ThresholdScreener,
-        verifier: ThresholdVerifier,
+        screener: Screener,
+        verifier: Verifier,
         threshold_start: int,
         threshold_max: int,
         sample_range: float,
@@ -343,38 +407,32 @@ class TouchCalibrateMacro(Macro):
         verification_samples: int,
     ) -> int | None:
         """
-        Find the minimum threshold that produces consistent results.
+        Find the best threshold that produces consistent results.
 
         Strategy:
         1. Screen with few samples - pass if any valid subset found
         2. If screening passes, verify with multiple actual touch probes
-        3. Accept if probe results are consistent
+        3. Once a passing threshold is found, optimize by searching higher
+           thresholds (up to 40% above) with a z_limit safety bound
+        4. Return the threshold with the best (lowest) median range
         """
         threshold = threshold_start
         screening_samples = self._config.touch.samples + self._config.touch.max_noisy_samples
 
         while threshold <= threshold_max:
-            # Phase 1: Quick screening
-            screening = screener.screen(threshold, screening_samples)
-
-            if screening is None:
-                threshold += calculate_step(threshold, None, sample_range)
-                continue
-
-            self._log_screening_result(screening, sample_range)
-
-            if not screening.passed(sample_range):
-                threshold += calculate_step(threshold, screening.best_range, sample_range)
-                continue
-
-            # Phase 2: Actual touch probe verification
-            verification = verifier.verify(threshold, max_verify_range, verification_samples)
+            verification, step = self._try_threshold(
+                screener,
+                verifier,
+                threshold,
+                screening_samples,
+                sample_range,
+                max_verify_range,
+                verification_samples,
+            )
 
             if verification is None:
-                threshold += calculate_step(threshold, None, sample_range)
+                threshold += step
                 continue
-
-            self._log_verification_result(verification, max_verify_range)
 
             if verification.passed(max_verify_range):
                 logger.info(
@@ -383,7 +441,16 @@ class TouchCalibrateMacro(Macro):
                     format_distance(verification.median_range),
                     len(verification.probe_medians),
                 )
-                return threshold
+                return self._optimize_threshold(
+                    screener,
+                    verifier,
+                    threshold,
+                    verification,
+                    threshold_max,
+                    sample_range,
+                    max_verify_range,
+                    verification_samples,
+                )
 
             # Consistency check failed - increase threshold
             logger.debug(
@@ -391,9 +458,107 @@ class TouchCalibrateMacro(Macro):
                 format_distance(verification.median_range),
                 format_distance(max_verify_range),
             )
-            threshold += calculate_step(threshold, verification.median_range, sample_range)
+            threshold += step
 
         return None
+
+    def _optimize_threshold(
+        self,
+        screener: Screener,
+        verifier: Verifier,
+        first_threshold: int,
+        first_verification: VerificationResult,
+        threshold_max: int,
+        sample_range: float,
+        max_verify_range: float,
+        verification_samples: int,
+    ) -> int:
+        """
+        Optimize by searching higher thresholds for better accuracy.
+
+        After finding the first passing threshold, try candidates at 10%,
+        20%, 30%, and 40% above it (capped at threshold_max) with a z_limit
+        safety bound computed from the first verification's probe medians.
+        Returns the threshold with the lowest median_range.
+        """
+        # Already at the natural floor — can't improve
+        if first_verification.median_range <= sample_range:
+            logger.info(
+                "Threshold %d already at optimal accuracy (%smm <= %smm sample range), skipping optimization.",
+                first_threshold,
+                format_distance(first_verification.median_range),
+                format_distance(sample_range),
+            )
+            return first_threshold
+
+        # Compute z_limit from first verification
+        z_limit = min(first_verification.probe_medians) - max_verify_range
+        optimization_max = min(int(first_threshold * 1.4), threshold_max)
+        screening_samples = self._config.touch.samples + self._config.touch.max_noisy_samples
+
+        logger.info(
+            "Optimizing: searching thresholds %d-%d with z_limit=%.4fmm",
+            first_threshold,
+            optimization_max,
+            z_limit,
+        )
+
+        best_threshold = first_threshold
+        best_range = first_verification.median_range
+
+        candidates = list(
+            dict.fromkeys(min(int(first_threshold * mult), optimization_max) for mult in (1.1, 1.2, 1.3, 1.4))
+        )
+
+        for threshold in candidates:
+            verification, _step = self._try_threshold(
+                screener,
+                verifier,
+                threshold,
+                screening_samples,
+                sample_range,
+                max_verify_range,
+                verification_samples,
+                z_limit=z_limit,
+            )
+
+            if verification is None:
+                continue
+
+            if verification.passed(max_verify_range) and verification.median_range < best_range:
+                logger.info(
+                    "Optimization: threshold %d improved accuracy %smm -> %smm",
+                    threshold,
+                    format_distance(best_range),
+                    format_distance(verification.median_range),
+                )
+                best_threshold = threshold
+                best_range = verification.median_range
+
+                # Definitely satisfied — can't improve beyond per-probe noise
+                if best_range <= sample_range:
+                    logger.info(
+                        "Optimization: reached optimal accuracy (%smm <= %smm sample range), stopping.",
+                        format_distance(best_range),
+                        format_distance(sample_range),
+                    )
+                    break
+
+        if best_threshold != first_threshold:
+            logger.info(
+                "Optimization complete: threshold %d -> %d (accuracy %smm)",
+                first_threshold,
+                best_threshold,
+                format_distance(best_range),
+            )
+        else:
+            logger.info(
+                "Optimization complete: threshold %d remains best (accuracy %smm)",
+                best_threshold,
+                format_distance(best_range),
+            )
+
+        return best_threshold
 
     def _log_calibration_failure(
         self,
@@ -536,7 +701,7 @@ class CalibrationTouchMode(TouchMode):
 
         return tuple(sorted(samples))
 
-    def perform_touch_probe(self) -> float:
+    def perform_touch_probe(self, *, z_limit: float | None = None) -> float:
         """
         Perform one complete touch probe sequence.
 
@@ -544,7 +709,7 @@ class CalibrationTouchMode(TouchMode):
         the runtime TouchMode._run_probe() logic.
         """
         return run_probe_sequence(
-            self._perform_single_probe,
+            lambda: self._perform_single_probe(z_limit=z_limit),
             samples=self._config.samples,
             max_samples=self._config.max_samples,
             max_window=self._config.max_window,

--- a/src/cartographer/probe/touch_mode.py
+++ b/src/cartographer/probe/touch_mode.py
@@ -253,7 +253,7 @@ class TouchMode(TouchModelSelectorMixin, ProbeMode, Endstop):
             sample_range=self._config.sample_range,
         )
 
-    def _perform_single_probe(self) -> float:
+    def _perform_single_probe(self, *, z_limit: float | None = None) -> float:
         model = self.get_model()
         if self._toolhead.get_position().z < self._config.retract_distance:
             self._toolhead.move(z=self._config.retract_distance, speed=self._config.lift_speed)
@@ -269,7 +269,7 @@ class TouchMode(TouchModelSelectorMixin, ProbeMode, Endstop):
             pass
 
         try:
-            trigger_pos = self._toolhead.z_probing_move(self, speed=model.speed)
+            trigger_pos = self._toolhead.z_probing_move(self, speed=model.speed, z_limit=z_limit)
         finally:
             self._toolhead.set_max_accel(max_accel)
 

--- a/src/cartographer/toolhead.py
+++ b/src/cartographer/toolhead.py
@@ -44,8 +44,8 @@ class BacklashCompensatingToolhead(Toolhead):
         return self.toolhead.get_gcode_z_offset()
 
     @override
-    def z_probing_move(self, endstop: Endstop, *, speed: float) -> float:
-        return self.toolhead.z_probing_move(endstop, speed=speed)
+    def z_probing_move(self, endstop: Endstop, *, speed: float, z_limit: float | None = None) -> float:
+        return self.toolhead.z_probing_move(endstop, speed=speed, z_limit=z_limit)
 
     @override
     def z_home_end(self, endstop: Endstop) -> None:

--- a/tests/macros/test_touch_calibrate.py
+++ b/tests/macros/test_touch_calibrate.py
@@ -8,11 +8,13 @@ from cartographer.macros.touch.calibrate import (
     ScreeningResult,
     ThresholdScreener,
     ThresholdVerifier,
+    TouchCalibrateMacro,
     VerificationResult,
     calculate_step,
     format_distance,
 )
 from cartographer.probe.touch_mode import TouchError
+from tests.mocks.config import MockConfiguration
 
 # --- Fake probe for testing ---
 
@@ -46,7 +48,8 @@ class FakeCalibrationProbe:
     def set_threshold(self, threshold: int) -> None:
         self.thresholds_set.append(threshold)
 
-    def perform_touch_probe(self) -> float:
+    def perform_touch_probe(self, *, z_limit: float | None = None) -> float:
+        del z_limit
         result = self._probe_results.pop(0)
         if isinstance(result, RuntimeError):
             raise result
@@ -317,3 +320,343 @@ class TestCalculateStep:
         """Range just above 10x uses large step."""
         step = calculate_step(threshold=1000, range_value=0.101, sample_range=0.010)
         assert step == 200  # 0.101 > 10 * 0.010, uses 20%
+
+
+# --- Helpers for _find_threshold / _optimize_threshold tests ---
+
+
+def _make_macro() -> TouchCalibrateMacro:
+    """Create a TouchCalibrateMacro with only _config set (for testing private methods)."""
+    macro = object.__new__(TouchCalibrateMacro)
+    macro._config = MockConfiguration()  # pyright: ignore[reportPrivateUsage]  # samples=5, max_noisy_samples=2
+    return macro
+
+
+@final
+class FakeScreener:
+    """Fake ThresholdScreener that returns predetermined results.
+
+    Results are returned in order. If exhausted, returns a passing ScreeningResult.
+    """
+
+    def __init__(self, results: list[ScreeningResult | None]) -> None:
+        self._results = list(results)
+
+    def screen(self, threshold: int, sample_count: int) -> ScreeningResult | None:  # noqa: ARG002
+        if self._results:
+            return self._results.pop(0)
+        # Default: passes screening
+        return ScreeningResult(
+            threshold=threshold,
+            samples=(1.000,) * sample_count,
+            best_subset=[1.000] * sample_count,
+            best_range=0.001,
+        )
+
+
+@final
+class FakeVerifier:
+    """Fake ThresholdVerifier that returns predetermined results.
+
+    Results are returned in order. Tracks z_limit values passed.
+    """
+
+    def __init__(self, results: list[VerificationResult | None]) -> None:
+        self._results = list(results)
+        self.z_limits: list[float | None] = []
+
+    def verify(
+        self,
+        threshold: int,
+        max_verify_range: float,
+        sample_count: int,
+        *,
+        z_limit: float | None = None,
+    ) -> VerificationResult | None:
+        del threshold, max_verify_range, sample_count
+        self.z_limits.append(z_limit)
+        return self._results.pop(0)
+
+
+# --- _find_threshold with optimization ---
+
+
+class TestFindThreshold:
+    def test_returns_first_threshold_when_already_optimal(self):
+        """When first verification median_range <= sample_range, skip optimization."""
+        macro = _make_macro()
+
+        screener = FakeScreener(
+            [
+                ScreeningResult(threshold=1000, samples=(1.0,), best_subset=[1.0], best_range=0.005),
+            ]
+        )
+        verifier = FakeVerifier(
+            [
+                VerificationResult(threshold=1000, probe_medians=[1.000, 1.005, 1.003], median_range=0.005),
+            ]
+        )
+
+        result = macro._find_threshold(  # pyright: ignore[reportPrivateUsage]
+            screener,
+            verifier,
+            threshold_start=1000,
+            threshold_max=5000,
+            sample_range=0.010,
+            max_verify_range=0.020,
+            verification_samples=3,
+        )
+
+        assert result == 1000
+        # Verifier should not have been called with z_limit (no optimization)
+        assert verifier.z_limits == [None]
+
+    def test_optimization_finds_better_threshold(self):
+        """Optimization finds a higher threshold with better accuracy."""
+        macro = _make_macro()
+
+        # First pass: threshold 1000 passes verification with 0.015mm range
+        # Optimization: threshold 1100 passes with 0.008mm range
+        screener = FakeScreener(
+            [
+                # Initial screening at 1000
+                ScreeningResult(threshold=1000, samples=(1.0,), best_subset=[1.0], best_range=0.005),
+                # Optimization screening at 1100
+                ScreeningResult(threshold=1100, samples=(1.0,), best_subset=[1.0], best_range=0.005),
+            ]
+        )
+        verifier = FakeVerifier(
+            [
+                # Initial verification at 1000
+                VerificationResult(threshold=1000, probe_medians=[1.000, 1.010, 1.015], median_range=0.015),
+                # Optimization verification at 1100 — better!
+                VerificationResult(threshold=1100, probe_medians=[1.000, 1.004, 1.008], median_range=0.008),
+            ]
+        )
+
+        result = macro._find_threshold(  # pyright: ignore[reportPrivateUsage]
+            screener,
+            verifier,
+            threshold_start=1000,
+            threshold_max=5000,
+            sample_range=0.010,
+            max_verify_range=0.020,
+            verification_samples=3,
+        )
+
+        assert result == 1100
+        # First verify: no z_limit; optimization verify: with z_limit
+        assert verifier.z_limits[0] is None
+        assert verifier.z_limits[1] is not None
+        assert verifier.z_limits[1] == pytest.approx(1.000 - 0.020)  # pyright: ignore[reportUnknownMemberType]
+
+    def test_optimization_keeps_first_when_no_improvement(self):
+        """If optimization candidates don't improve, keep first threshold."""
+        macro = _make_macro()
+
+        screener = FakeScreener(
+            [
+                # Initial screening at 1000
+                ScreeningResult(threshold=1000, samples=(1.0,), best_subset=[1.0], best_range=0.005),
+                # Optimization screening at 1100
+                ScreeningResult(threshold=1100, samples=(1.0,), best_subset=[1.0], best_range=0.005),
+                # Optimization screening at 1200
+                ScreeningResult(threshold=1200, samples=(1.0,), best_subset=[1.0], best_range=0.005),
+            ]
+        )
+        verifier = FakeVerifier(
+            [
+                # Initial verification at 1000 — 0.015mm
+                VerificationResult(threshold=1000, probe_medians=[1.000, 1.010, 1.015], median_range=0.015),
+                # Optimization verification at 1100 — worse (0.018mm)
+                VerificationResult(threshold=1100, probe_medians=[1.000, 1.010, 1.018], median_range=0.018),
+                # Optimization verification at 1200 — also worse (0.017mm)
+                VerificationResult(threshold=1200, probe_medians=[1.000, 1.010, 1.017], median_range=0.017),
+            ]
+        )
+
+        result = macro._find_threshold(  # pyright: ignore[reportPrivateUsage]
+            screener,
+            verifier,
+            threshold_start=1000,
+            threshold_max=1200,
+            sample_range=0.010,
+            max_verify_range=0.020,
+            verification_samples=3,
+        )
+
+        assert result == 1000
+
+    def test_optimization_stops_early_when_definitely_satisfied(self):
+        """Optimization exits early when median_range <= sample_range."""
+        macro = _make_macro()
+
+        screener = FakeScreener(
+            [
+                # Initial screening at 1000
+                ScreeningResult(threshold=1000, samples=(1.0,), best_subset=[1.0], best_range=0.005),
+                # Optimization screening at 1100 — first opt candidate
+                ScreeningResult(threshold=1100, samples=(1.0,), best_subset=[1.0], best_range=0.005),
+                # This should NOT be reached due to early exit
+                ScreeningResult(threshold=1200, samples=(1.0,), best_subset=[1.0], best_range=0.005),
+            ]
+        )
+        verifier = FakeVerifier(
+            [
+                # Initial verification at 1000 — 0.015mm (not optimal)
+                VerificationResult(threshold=1000, probe_medians=[1.000, 1.010, 1.015], median_range=0.015),
+                # Optimization at 1100 — 0.008mm (<= 0.010 sample_range → definitely satisfied)
+                VerificationResult(threshold=1100, probe_medians=[1.000, 1.004, 1.008], median_range=0.008),
+            ]
+        )
+
+        result = macro._find_threshold(  # pyright: ignore[reportPrivateUsage]
+            screener,
+            verifier,
+            threshold_start=1000,
+            threshold_max=5000,
+            sample_range=0.010,
+            max_verify_range=0.020,
+            verification_samples=3,
+        )
+
+        assert result == 1100
+        # Only 2 verify calls — didn't continue after definitely satisfied
+        assert len(verifier.z_limits) == 2
+
+    def test_optimization_bounded_by_threshold_max(self):
+        """Optimization doesn't exceed threshold_max even if 40% would go higher."""
+        macro = _make_macro()
+
+        # threshold 4500, optimization_max = min(int(4500 * 1.4), 5000) = 5000
+        # Candidates: int(4500 * 1.1) = 4950, int(4500 * 1.2) = 5400 -> 5000 (deduped)
+        # So only [4950, 5000] are tried
+        screener = FakeScreener(
+            [
+                ScreeningResult(threshold=4500, samples=(1.0,), best_subset=[1.0], best_range=0.005),
+                # Optimization at 4950
+                ScreeningResult(threshold=4950, samples=(1.0,), best_subset=[1.0], best_range=0.005),
+                # Optimization at 5000 (capped)
+                ScreeningResult(threshold=5000, samples=(1.0,), best_subset=[1.0], best_range=0.005),
+            ]
+        )
+        verifier = FakeVerifier(
+            [
+                # Initial at 4500
+                VerificationResult(threshold=4500, probe_medians=[1.000, 1.010, 1.015], median_range=0.015),
+                # Optimization at 4950 — slightly worse, so first stays best
+                VerificationResult(threshold=4950, probe_medians=[1.000, 1.010, 1.018], median_range=0.018),
+                # Optimization at 5000 — also worse
+                VerificationResult(threshold=5000, probe_medians=[1.000, 1.010, 1.019], median_range=0.019),
+            ]
+        )
+
+        result = macro._find_threshold(  # pyright: ignore[reportPrivateUsage]
+            screener,
+            verifier,
+            threshold_start=4500,
+            threshold_max=5000,
+            sample_range=0.010,
+            max_verify_range=0.020,
+            verification_samples=3,
+        )
+
+        assert result == 4500  # No improvement found, original stays
+
+    def test_returns_none_when_no_threshold_passes(self):
+        """Returns None when all thresholds fail screening."""
+        macro = _make_macro()
+
+        # All screenings fail
+        screener = FakeScreener(
+            [
+                ScreeningResult(threshold=500, samples=(1.0,), best_subset=None, best_range=float("inf")),
+                ScreeningResult(threshold=600, samples=(1.0,), best_subset=None, best_range=float("inf")),
+                ScreeningResult(threshold=700, samples=(1.0,), best_subset=None, best_range=float("inf")),
+                ScreeningResult(threshold=800, samples=(1.0,), best_subset=None, best_range=float("inf")),
+                ScreeningResult(threshold=900, samples=(1.0,), best_subset=None, best_range=float("inf")),
+                ScreeningResult(threshold=1000, samples=(1.0,), best_subset=None, best_range=float("inf")),
+            ]
+        )
+        verifier = FakeVerifier([])
+
+        result = macro._find_threshold(  # pyright: ignore[reportPrivateUsage]
+            screener,
+            verifier,
+            threshold_start=500,
+            threshold_max=1000,
+            sample_range=0.010,
+            max_verify_range=0.020,
+            verification_samples=3,
+        )
+
+        assert result is None
+
+    def test_optimization_z_limit_computed_correctly(self):
+        """z_limit is min(probe_medians) - max_verify_range from first verification."""
+        macro = _make_macro()
+
+        screener = FakeScreener(
+            [
+                ScreeningResult(threshold=1000, samples=(1.0,), best_subset=[1.0], best_range=0.005),
+            ]
+        )
+
+        probe_medians = [5.100, 5.110, 5.105]  # min = 5.100
+        max_verify_range = 0.020
+        expected_z_limit = 5.100 - 0.020  # = 5.080
+
+        verifier = FakeVerifier(
+            [
+                VerificationResult(threshold=1000, probe_medians=probe_medians, median_range=0.015),
+                # Optimization candidate — just needs to exist to check z_limit
+                VerificationResult(threshold=1100, probe_medians=[5.100, 5.105, 5.108], median_range=0.008),
+            ]
+        )
+
+        _ = macro._find_threshold(  # pyright: ignore[reportPrivateUsage]
+            screener,
+            verifier,
+            threshold_start=1000,
+            threshold_max=5000,
+            sample_range=0.010,
+            max_verify_range=max_verify_range,
+            verification_samples=3,
+        )
+
+        # First verify has no z_limit, optimization verify has computed z_limit
+        assert verifier.z_limits[0] is None
+        assert verifier.z_limits[1] == pytest.approx(expected_z_limit)  # pyright: ignore[reportUnknownMemberType]
+
+    def test_screening_failure_during_optimization_does_not_crash(self):
+        """Screening returning None during optimization is handled gracefully."""
+        macro = _make_macro()
+
+        # threshold 1000, optimization_max = min(1400, 1200) = 1200
+        # Candidates: [1100, 1200]
+        # At 1100: screening returns None -> skip. At 1200: also None -> skip.
+        screener = FakeScreener(
+            [
+                ScreeningResult(threshold=1000, samples=(1.0,), best_subset=[1.0], best_range=0.005),
+                None,  # Trigger error at 1100 during optimization
+                None,  # Trigger error at 1200 during optimization
+            ]
+        )
+        verifier = FakeVerifier(
+            [
+                VerificationResult(threshold=1000, probe_medians=[1.000, 1.010, 1.015], median_range=0.015),
+            ]
+        )
+
+        result = macro._find_threshold(  # pyright: ignore[reportPrivateUsage]
+            screener,
+            verifier,
+            threshold_start=1000,
+            threshold_max=1200,
+            sample_range=0.010,
+            max_verify_range=0.020,
+            verification_samples=3,
+        )
+
+        # Falls back to first threshold since no improvement was found
+        assert result == 1000


### PR DESCRIPTION
## Summary

After finding the first passing threshold during touch calibration, an optimization phase now continues searching up to 20% higher thresholds to find one with better accuracy (lower median range). A `z_limit` safety bound computed from the first verification's probe medians prevents the probe from traveling too far during optimization.

### Changes

- **z_limit threading**: Added `z_limit: float | None = None` parameter through the entire probe call chain (`Toolhead.z_probing_move` → `KlipperLikeToolhead` → `BacklashCompensatingToolhead` → `TouchMode._perform_single_probe` → `CalibrationProbe` protocol → `ThresholdVerifier.verify` → `CalibrationTouchMode.perform_touch_probe`)
- **Optimization phase**: `_find_threshold` now calls `_optimize_threshold` after finding the first passing threshold. Optimization searches higher thresholds with the z_limit active, tracking the best (lowest) median range
- **Definitely-satisfied early exit**: If `median_range <= sample_range`, optimization stops immediately — this is the natural accuracy floor
- **Screener/Verifier protocols**: Added `Screener` and `Verifier` protocols (matching existing `CalibrationProbe` pattern) for clean testability
- **`_try_threshold` refactor**: Extracted shared screen→log→verify→log sequence into `_try_threshold` helper, eliminating duplication between `_find_threshold` and `_optimize_threshold`
- **8 new tests**: Covers already-optimal, finds-better, no-improvement, early-exit, bounded-by-max, none-found, z_limit computation, and screening-failure scenarios

### z_limit computation

```
z_limit = min(first_verification.probe_medians) - max_verify_range
```

This ensures the probe never travels further than the known trigger zone minus the acceptable range, preventing physical damage from excessively high thresholds.