### PR TITLE
fix(stream): resolve relative FILE paths to temp directory

### DIFF
--- a/src/cartographer/lib/csv.py
+++ b/src/cartographer/lib/csv.py
@@ -36,6 +36,10 @@ def generate_filepath(label: str) -> str:
 
 def validate_output_path(output_file: str) -> None:
     """Validate that we can write to the output path."""
+    if not output_file.endswith(".csv"):
+        msg = f"Output file must have a .csv extension, got: {output_file}"
+        raise RuntimeError(msg)
+
     # Check if parent directory exists and is writable
     output_file = resolve_filepath(output_file)
     parent_dir = os.path.dirname(output_file)
@@ -57,5 +61,12 @@ def validate_output_path(output_file: str) -> None:
 
 
 def resolve_filepath(path: str) -> str:
-    """Expand ~ and environment variables in a file path."""
-    return os.path.expandvars(os.path.expanduser(path))
+    """Expand ~ and environment variables in a file path.
+
+    If the resulting path is relative (no directory component like ``/`` or ``~``),
+    it is placed in the system temp directory so the file is easy to find.
+    """
+    expanded = os.path.expandvars(os.path.expanduser(path))
+    if not os.path.isabs(expanded):
+        expanded = os.path.join(tempfile.gettempdir(), expanded)
+    return expanded

--- a/src/cartographer/macros/stream.py
+++ b/src/cartographer/macros/stream.py
@@ -63,7 +63,7 @@ class StreamMacro(Macro):
         output_file = p.file or generate_filepath("stream")
 
         validate_output_path(output_file)
-        self._output_file = output_file
+        self._output_file = resolve_filepath(output_file)
 
         # Start the streaming session
         self._active_session = self._mcu.start_session()


### PR DESCRIPTION
## Summary
- When users provide a relative `FILE` parameter to `CARTOGRAPHER_STREAM` (e.g. `stream_data_1.csv`), the file is now placed in the system temp directory instead of relative to the Klipper process working directory, making it easy to find.
- Validates that the output file has a `.csv` extension.

## Test plan
- [x] Existing tests pass (`uv run pytest tests/test_stream.py`)
- [x] Manual: `CARTOGRAPHER_STREAM ACTION=START FILE=my_data.csv` → logged path should show `/tmp/my_data.csv`
- [x] Manual: `CARTOGRAPHER_STREAM ACTION=START FILE=my_data.txt` → should error about `.csv` extension
- [x] Manual: `CARTOGRAPHER_STREAM ACTION=START FILE=/home/user/data.csv` → absolute path should be used as-is

🤖 Generated with [Claude Code](https://claude.com/claude-code)