### PR TITLE
fix(mcu): support non-critical MCU reconnect

### DIFF
--- a/src/cartographer/adapters/klipper/mcu/commands.py
+++ b/src/cartographer/adapters/klipper/mcu/commands.py
@@ -31,39 +31,49 @@ class ThresholdCommand(NamedTuple):
 @final
 class KlipperCartographerCommands:
     def __init__(self, mcu: MCU):
-        self._command_queue = mcu.alloc_command_queue()
-        self._stream_command = mcu.lookup_command("cartographer_stream en=%u", cq=self._command_queue)
-        self._set_threshold_command = mcu.lookup_command(
-            "cartographer_set_threshold trigger=%u untrigger=%u", cq=self._command_queue
+        self._mcu = mcu
+        self._command_queue = None
+        self._stream_command: CommandWrapper | None = None
+        self._set_threshold_command: CommandWrapper | None = None
+        self._start_home_command: CommandWrapper | None = None
+        self._stop_home_command: CommandWrapper | None = None
+
+    def build_config(self) -> None:
+        command_queue = self._mcu.alloc_command_queue()
+        self._stream_command = self._mcu.lookup_command("cartographer_stream en=%u", cq=command_queue)
+        self._set_threshold_command = self._mcu.lookup_command(
+            "cartographer_set_threshold trigger=%u untrigger=%u",
+            cq=command_queue,
         )
-        self._start_home_command = mcu.lookup_command(
+        self._start_home_command = self._mcu.lookup_command(
             "cartographer_home trsync_oid=%c trigger_reason=%c trigger_invert=%c threshold=%u trigger_method=%u",
-            cq=self._command_queue,
+            cq=command_queue,
         )
-        self._stop_home_command = mcu.lookup_command("cartographer_stop_home", cq=self._command_queue)
+        self._stop_home_command = self._mcu.lookup_command("cartographer_stop_home", cq=command_queue)
+        self._command_queue = command_queue
 
     def _ensure_initialized(self, command: CommandWrapper | None, name: str) -> CommandWrapper:
         if command is None:
-            msg = f"Command {name} has not been initialized"
+            msg = f"{name} has not been initialized"
             raise RuntimeError(msg)
         return command
 
     def send_stream_state(self, *, enable: bool) -> None:
-        command = self._ensure_initialized(self._stream_command, "stream command")
+        command = self._ensure_initialized(self._stream_command, "Stream command")
         logger.debug("%s stream", "Starting" if enable else "Stopping")
         command.send([1 if enable else 0])
 
     def send_threshold(self, command: ThresholdCommand) -> None:
-        cmd = self._ensure_initialized(self._set_threshold_command, "set threshold command")
+        cmd = self._ensure_initialized(self._set_threshold_command, "Set threshold command")
         logger.debug("Sending trigger frequency threshold command %s", list(command))
         cmd.send(list(command))
 
     def send_home(self, command: HomeCommand) -> None:
-        cmd = self._ensure_initialized(self._start_home_command, "start home command")
+        cmd = self._ensure_initialized(self._start_home_command, "Start home command")
         logger.debug("Sending home command %s", list(command))
         cmd.send(list(command))
 
     def send_stop_home(self) -> None:
-        cmd = self._ensure_initialized(self._stop_home_command, "stop home command")
+        cmd = self._ensure_initialized(self._stop_home_command, "Stop home command")
         logger.debug("Sending stop home command")
         cmd.send()

--- a/src/cartographer/adapters/klipper/mcu/commands.py
+++ b/src/cartographer/adapters/klipper/mcu/commands.py
@@ -52,6 +52,10 @@ class KlipperCartographerCommands:
         self._stop_home_command = self._mcu.lookup_command("cartographer_stop_home", cq=command_queue)
         self._command_queue = command_queue
 
+    @property
+    def is_initialized(self) -> bool:
+        return self._command_queue is not None
+
     def _ensure_initialized(self, command: CommandWrapper | None, name: str) -> CommandWrapper:
         if command is None:
             msg = f"{name} has not been initialized"

--- a/src/cartographer/adapters/klipper/mcu/constants.py
+++ b/src/cartographer/adapters/klipper/mcu/constants.py
@@ -37,13 +37,14 @@ class KlipperCartographerConstants:
 
     def __init__(self, mcu: MCU):
         self._mcu = mcu
-        self._command_queue = self._mcu.alloc_command_queue()
-        self._mcu.register_config_callback(self._initialize_constants)
+        self._command_queue = None
 
         self.thermistor = Thermistor(10000.0, 0.0)
         self.thermistor.setup_coefficients_beta(25.0, 47000.0, 4041.0)
 
-    def _initialize_constants(self):
+    def build_config(self):
+        command_queue = self._mcu.alloc_command_queue()
+
         constants = self._mcu.get_constants()
         self._sensor_frequency = self._clock_to_sensor_frequency(float(constants["CLOCK_FREQ"]))
         self._inverse_adc_max = 1.0 / int(constants["ADC_MAX"])
@@ -53,9 +54,10 @@ class KlipperCartographerConstants:
         base_read_command = self._mcu.lookup_query_command(
             "cartographer_base_read len=%c offset=%hu",
             "cartographer_base_data bytes=%*s offset=%hu",
-            cq=self._command_queue,
+            cq=command_queue,
         )
         self._read_base(base_read_command)
+        self._command_queue = command_queue
 
     def _read_base(self, cmd: CommandQueryWrapper[_BaseData]) -> None:
         fixed_length = 6

--- a/src/cartographer/adapters/klipper/mcu/mcu.py
+++ b/src/cartographer/adapters/klipper/mcu/mcu.py
@@ -46,29 +46,12 @@ class _RawData(TypedDict):
 
 @final
 class KlipperCartographerMcu(Mcu, KlipperStreamMcu):
-    _constants: KlipperCartographerConstants | None = None
-    _commands: KlipperCartographerCommands | None = None
-
-    @property
-    def constants(self) -> KlipperCartographerConstants:
-        if self._constants is None:
-            msg = "Mcu not initialized"
-            raise RuntimeError(msg)
-        return self._constants
-
     @override
     def get_coil_reference(self) -> CoilCalibrationReference:
         return CoilCalibrationReference(
-            min_frequency=self.constants.count_to_frequency(self.constants.minimum_count),
-            min_frequency_temperature=self.constants.calculate_temperature(self.constants.minimum_adc_count),
+            min_frequency=self._constants.count_to_frequency(self._constants.minimum_count),
+            min_frequency_temperature=self._constants.calculate_temperature(self._constants.minimum_adc_count),
         )
-
-    @property
-    def commands(self) -> KlipperCartographerCommands:
-        if self._commands is None:
-            msg = "Mcu not initialized"
-            raise RuntimeError(msg)
-        return self._commands
 
     @cached_property
     def kinematics(self):
@@ -83,6 +66,8 @@ class KlipperCartographerMcu(Mcu, KlipperStreamMcu):
         self._sensor_ready = False
         self.printer = config.get_printer()
         self.klipper_mcu = mcu.get_printer_mcu(self.printer, mcu_name)
+        self._constants = KlipperCartographerConstants(self.klipper_mcu)
+        self._commands = KlipperCartographerCommands(self.klipper_mcu)
         self._reactor: Reactor = self.klipper_mcu.get_printer().get_reactor()
         self._stream = KlipperStream[Sample](self, self._reactor)
         self.dispatch = KlipperTriggerDispatch(self.klipper_mcu)
@@ -100,12 +85,18 @@ class KlipperCartographerMcu(Mcu, KlipperStreamMcu):
         self.printer.register_event_handler("klippy:connect", self._handle_connect)
         self.printer.register_event_handler("klippy:shutdown", self._handle_shutdown)
         self.klipper_mcu.register_config_callback(self._initialize)
+        get_reconnect_event = getattr(self.klipper_mcu, "get_non_critical_reconnect_event_name", None)
+        if get_reconnect_event is not None:
+            self.printer.register_event_handler(
+                get_reconnect_event(),
+                self._handle_reconnect,
+            )
 
     @override
     def get_status(self, eventtime: float) -> dict[str, object]:
         return {
             "last_sample": asdict(self._stream.last_item) if self._stream.last_item else None,
-            "constants": self._constants.get_status() if self._constants else None,
+            "constants": self._constants.get_status(),
         }
 
     @override
@@ -113,8 +104,9 @@ class KlipperCartographerMcu(Mcu, KlipperStreamMcu):
         return self._stream.last_item
 
     def _initialize(self) -> None:
-        self._constants = KlipperCartographerConstants(self.klipper_mcu)
-        self._commands = KlipperCartographerCommands(self.klipper_mcu)
+        self._constants.build_config()
+        self._commands.build_config()
+        self.stop_streaming()
         self._register_data_response()
         logger.info("Initialized %s MCU", self.klipper_mcu.get_status()["mcu_version"])
 
@@ -144,7 +136,7 @@ class KlipperCartographerMcu(Mcu, KlipperStreamMcu):
         self._set_threshold(frequency)
         completion = self.dispatch.start(print_time)
 
-        self.commands.send_home(
+        self._commands.send_home(
             HomeCommand(
                 trsync_oid=self.dispatch.get_oid(),
                 trigger_reason=MCU_trsync.REASON_ENDSTOP_HIT,
@@ -161,7 +153,7 @@ class KlipperCartographerMcu(Mcu, KlipperStreamMcu):
 
         completion = self.dispatch.start(print_time)
 
-        self.commands.send_home(
+        self._commands.send_home(
             HomeCommand(
                 trsync_oid=self.dispatch.get_oid(),
                 trigger_reason=MCU_trsync.REASON_ENDSTOP_HIT,
@@ -175,7 +167,7 @@ class KlipperCartographerMcu(Mcu, KlipperStreamMcu):
     @override
     def stop_homing(self, home_end_time: float) -> float:
         self.dispatch.wait_end(home_end_time)
-        self.commands.send_stop_home()
+        self._commands.send_stop_home()
         result = self.dispatch.stop()
         if result >= MCU_trsync.REASON_COMMS_TIMEOUT:
             msg = "Communication timeout during homing"
@@ -200,21 +192,23 @@ class KlipperCartographerMcu(Mcu, KlipperStreamMcu):
 
     @override
     def start_streaming(self) -> None:
-        self.commands.send_stream_state(enable=True)
+        self._commands.send_stream_state(enable=True)
 
     @override
     def stop_streaming(self) -> None:
-        self.commands.send_stream_state(enable=False)
+        if not self._commands.is_initialized:
+            return
+        self._commands.send_stream_state(enable=False)
 
     @override
     def get_current_time(self) -> float:
         return self.printer.get_reactor().monotonic()
 
     def _set_threshold(self, trigger_frequency: float) -> None:
-        trigger = self.constants.frequency_to_count(trigger_frequency)
-        untrigger = self.constants.frequency_to_count(trigger_frequency * (1 - TRIGGER_HYSTERESIS))
+        trigger = self._constants.frequency_to_count(trigger_frequency)
+        untrigger = self._constants.frequency_to_count(trigger_frequency * (1 - TRIGGER_HYSTERESIS))
 
-        self.commands.send_threshold(ThresholdCommand(trigger, untrigger))
+        self._commands.send_threshold(ThresholdCommand(trigger, untrigger))
 
     def _handle_mcu_identify(self) -> None:
         for stepper in self.kinematics.get_steppers():
@@ -222,9 +216,14 @@ class KlipperCartographerMcu(Mcu, KlipperStreamMcu):
                 self.dispatch.add_stepper(stepper)
 
     def _handle_connect(self) -> None:
-        self.stop_streaming()
+        pass
 
     def _handle_shutdown(self) -> None:
+        self.stop_streaming()
+
+    def _handle_reconnect(self) -> None:
+        self._sensor_ready = False
+        self._data_error = None
         self.stop_streaming()
 
     def _handle_data(self, data: _RawData) -> None:
@@ -259,8 +258,8 @@ class KlipperCartographerMcu(Mcu, KlipperStreamMcu):
         clock = self.klipper_mcu.clock32_to_clock64(data["clock"])
         time = self.klipper_mcu.clock_to_print_time(clock)
 
-        frequency = self.constants.count_to_frequency(count)
-        temperature = self.constants.calculate_temperature(data["temp"])
+        frequency = self._constants.count_to_frequency(count)
+        temperature = self._constants.calculate_temperature(data["temp"])
         position = self.get_requested_position(time)
 
         sample = Sample(
@@ -290,7 +289,7 @@ class KlipperCartographerMcu(Mcu, KlipperStreamMcu):
         error: str | None = None
         if count == SHORTED_FREQUENCY_VALUE:
             error = "coil is shorted or not connected."
-        elif count > self.constants.minimum_count * FREQUENCY_RANGE_PERCENT:
+        elif count > self._constants.minimum_count * FREQUENCY_RANGE_PERCENT:
             error = "coil frequency reading exceeded max expected value, received %(count)d"
 
         if self._data_error == error:


### PR DESCRIPTION
## Summary

Restructures the MCU adapter to support Kalico's non-critical MCU reconnection without breaking stock Klipper compatibility. The previous code created new `KlipperCartographerConstants`/`KlipperCartographerCommands` objects inside a config callback, which caused `register_config_callback` to fire during `_send_config` iteration on reconnect -- crashing Klipper with a query to an unconfigured MCU.

The fix moves object construction to `__init__` (lightweight, no MCU interaction) and extracts all MCU interaction into idempotent `build_config` methods that the parent orchestrates via a single config callback. A reconnect event handler resets plugin state (sensor readiness, error dedup, streaming) after successful reconnection.

## References

Closes #470

## Decisions & callouts

- `getattr` pattern used for Kalico-only `get_non_critical_reconnect_event_name` instead of `hasattr` + `cast` to avoid basedpyright `reportAttributeAccessIssue` and `reportExplicitAny` warnings.
- `build_config` is public (not `_build_config`) since the parent class calls it from outside the defining class -- avoids `reportPrivateUsage` warnings.
- `TriggerDispatch`/`MCU_trsync` stepper state is not reset on reconnect. Kalico's `_send_config` already re-invokes their config callbacks, rebuilding trsync OIDs and commands automatically.
- `_command_queue` is assigned last in `build_config` methods so that `is_initialized` only returns `True` when all commands are fully looked up -- prevents partial-init races.

## Testing

**Important:** Since the version string (`1.5.2.dev3`) matches the current release, pip will skip the install unless forced. You must use `--force-reinstall`:

```bash
~/klippy-env/bin/pip install --no-cache-dir --force-reinstall "git+https://github.com/Cartographer3D/cartographer3d-plugin.git@fix/non-critical-mcu-reconnect"
sudo systemctl restart klipper
```