### PR TITLE
feat(mcu): support Kalico non-critical MCU reconnection

### DIFF
--- a/src/cartographer/adapters/klipper/mcu/commands.py
+++ b/src/cartographer/adapters/klipper/mcu/commands.py
@@ -31,16 +31,24 @@ class ThresholdCommand(NamedTuple):
 @final
 class KlipperCartographerCommands:
     def __init__(self, mcu: MCU):
+        self._mcu = mcu
         self._command_queue = mcu.alloc_command_queue()
-        self._stream_command = mcu.lookup_command("cartographer_stream en=%u", cq=self._command_queue)
-        self._set_threshold_command = mcu.lookup_command(
-            "cartographer_set_threshold trigger=%u untrigger=%u", cq=self._command_queue
+        self._stream_command: CommandWrapper | None = None
+        self._set_threshold_command: CommandWrapper | None = None
+        self._start_home_command: CommandWrapper | None = None
+        self._stop_home_command: CommandWrapper | None = None
+
+    def initialize(self) -> None:
+        cq = self._command_queue
+        self._stream_command = self._mcu.lookup_command("cartographer_stream en=%u", cq=cq)
+        self._set_threshold_command = self._mcu.lookup_command(
+            "cartographer_set_threshold trigger=%u untrigger=%u", cq=cq
         )
-        self._start_home_command = mcu.lookup_command(
+        self._start_home_command = self._mcu.lookup_command(
             "cartographer_home trsync_oid=%c trigger_reason=%c trigger_invert=%c threshold=%u trigger_method=%u",
-            cq=self._command_queue,
+            cq=cq,
         )
-        self._stop_home_command = mcu.lookup_command("cartographer_stop_home", cq=self._command_queue)
+        self._stop_home_command = self._mcu.lookup_command("cartographer_stop_home", cq=cq)
 
     def _ensure_initialized(self, command: CommandWrapper | None, name: str) -> CommandWrapper:
         if command is None:

--- a/src/cartographer/adapters/klipper/mcu/commands.py
+++ b/src/cartographer/adapters/klipper/mcu/commands.py
@@ -50,11 +50,6 @@ class KlipperCartographerCommands:
         )
         self._stop_home_command = self._mcu.lookup_command("cartographer_stop_home", cq=cq)
 
-    def _check_connected(self) -> None:
-        if getattr(self._mcu, "non_critical_disconnected", False):
-            msg = "Cartographer MCU is disconnected"
-            raise RuntimeError(msg)
-
     def _ensure_initialized(self, command: CommandWrapper | None, name: str) -> CommandWrapper:
         if command is None:
             msg = f"Command {name} has not been initialized"
@@ -62,25 +57,21 @@ class KlipperCartographerCommands:
         return command
 
     def send_stream_state(self, *, enable: bool) -> None:
-        self._check_connected()
         command = self._ensure_initialized(self._stream_command, "stream command")
         logger.debug("%s stream", "Starting" if enable else "Stopping")
         command.send([1 if enable else 0])
 
     def send_threshold(self, command: ThresholdCommand) -> None:
-        self._check_connected()
         cmd = self._ensure_initialized(self._set_threshold_command, "set threshold command")
         logger.debug("Sending trigger frequency threshold command %s", list(command))
         cmd.send(list(command))
 
     def send_home(self, command: HomeCommand) -> None:
-        self._check_connected()
         cmd = self._ensure_initialized(self._start_home_command, "start home command")
         logger.debug("Sending home command %s", list(command))
         cmd.send(list(command))
 
     def send_stop_home(self) -> None:
-        self._check_connected()
         cmd = self._ensure_initialized(self._stop_home_command, "stop home command")
         logger.debug("Sending stop home command")
         cmd.send()

--- a/src/cartographer/adapters/klipper/mcu/commands.py
+++ b/src/cartographer/adapters/klipper/mcu/commands.py
@@ -50,6 +50,11 @@ class KlipperCartographerCommands:
         )
         self._stop_home_command = self._mcu.lookup_command("cartographer_stop_home", cq=cq)
 
+    def _check_connected(self) -> None:
+        if getattr(self._mcu, "non_critical_disconnected", False):
+            msg = "Cartographer MCU is disconnected"
+            raise RuntimeError(msg)
+
     def _ensure_initialized(self, command: CommandWrapper | None, name: str) -> CommandWrapper:
         if command is None:
             msg = f"Command {name} has not been initialized"
@@ -57,21 +62,25 @@ class KlipperCartographerCommands:
         return command
 
     def send_stream_state(self, *, enable: bool) -> None:
+        self._check_connected()
         command = self._ensure_initialized(self._stream_command, "stream command")
         logger.debug("%s stream", "Starting" if enable else "Stopping")
         command.send([1 if enable else 0])
 
     def send_threshold(self, command: ThresholdCommand) -> None:
+        self._check_connected()
         cmd = self._ensure_initialized(self._set_threshold_command, "set threshold command")
         logger.debug("Sending trigger frequency threshold command %s", list(command))
         cmd.send(list(command))
 
     def send_home(self, command: HomeCommand) -> None:
+        self._check_connected()
         cmd = self._ensure_initialized(self._start_home_command, "start home command")
         logger.debug("Sending home command %s", list(command))
         cmd.send(list(command))
 
     def send_stop_home(self) -> None:
+        self._check_connected()
         cmd = self._ensure_initialized(self._stop_home_command, "stop home command")
         logger.debug("Sending stop home command")
         cmd.send()

--- a/src/cartographer/adapters/klipper/mcu/constants.py
+++ b/src/cartographer/adapters/klipper/mcu/constants.py
@@ -38,12 +38,11 @@ class KlipperCartographerConstants:
     def __init__(self, mcu: MCU):
         self._mcu = mcu
         self._command_queue = self._mcu.alloc_command_queue()
-        self._mcu.register_config_callback(self._initialize_constants)
 
         self.thermistor = Thermistor(10000.0, 0.0)
         self.thermistor.setup_coefficients_beta(25.0, 47000.0, 4041.0)
 
-    def _initialize_constants(self):
+    def initialize(self):
         constants = self._mcu.get_constants()
         self._sensor_frequency = self._clock_to_sensor_frequency(float(constants["CLOCK_FREQ"]))
         self._inverse_adc_max = 1.0 / int(constants["ADC_MAX"])

--- a/src/cartographer/adapters/klipper/mcu/mcu.py
+++ b/src/cartographer/adapters/klipper/mcu/mcu.py
@@ -54,7 +54,7 @@ class KlipperCartographerMcu(Mcu, KlipperStreamMcu):
     @property
     def constants(self) -> KlipperCartographerConstants:
         if self._constants is None:
-            msg = "Mcu not initialized"
+            msg = "Cartographer MCU not initialized"
             raise RuntimeError(msg)
         return self._constants
 
@@ -68,7 +68,10 @@ class KlipperCartographerMcu(Mcu, KlipperStreamMcu):
     @property
     def commands(self) -> KlipperCartographerCommands:
         if self._commands is None:
-            msg = "Mcu not initialized"
+            msg = "Cartographer MCU not initialized"
+            raise RuntimeError(msg)
+        if getattr(self.klipper_mcu, "non_critical_disconnected", False):
+            msg = "Cartographer MCU is disconnected"
             raise RuntimeError(msg)
         return self._commands
 

--- a/src/cartographer/adapters/klipper/mcu/mcu.py
+++ b/src/cartographer/adapters/klipper/mcu/mcu.py
@@ -113,9 +113,14 @@ class KlipperCartographerMcu(Mcu, KlipperStreamMcu):
         return self._stream.last_item
 
     def _initialize(self) -> None:
-        self._constants = KlipperCartographerConstants(self.klipper_mcu)
-        self._commands = KlipperCartographerCommands(self.klipper_mcu)
+        if self._constants is None:
+            self._constants = KlipperCartographerConstants(self.klipper_mcu)
+        self._constants.initialize()
+        if self._commands is None:
+            self._commands = KlipperCartographerCommands(self.klipper_mcu)
+        self._commands.initialize()
         self._register_data_response()
+        self._sensor_ready = False
         logger.info("Initialized %s MCU", self.get_mcu_version() or "unknown")
 
     _DATA_MSG_FORMAT = "cartographer_data clock=%u data=%u temp=%u"

--- a/src/cartographer/adapters/klipper/mcu/mcu.py
+++ b/src/cartographer/adapters/klipper/mcu/mcu.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 import logging
 from dataclasses import asdict
 from functools import cached_property
-from typing import TYPE_CHECKING, Callable, TypedDict, final
+from typing import TYPE_CHECKING, TypedDict, final
 
 import mcu
 from mcu import MCU_trsync
@@ -29,6 +29,8 @@ from cartographer.adapters.klipper.mcu.stream import KlipperStream, KlipperStrea
 from cartographer.interfaces.printer import CoilCalibrationReference, Mcu, Position, Sample
 
 if TYPE_CHECKING:
+    from collections.abc import Callable
+
     from configfile import ConfigWrapper
     from reactor import Reactor, ReactorCompletion
 
@@ -81,6 +83,7 @@ class KlipperCartographerMcu(Mcu, KlipperStreamMcu):
         mcu_name: str,
     ):
         self._sensor_ready = False
+        self._reconnect_callbacks: list[Callable[[], None]] = []
         self.printer = config.get_printer()
         self.klipper_mcu = mcu.get_printer_mcu(self.printer, mcu_name)
         self._reactor: Reactor = self.klipper_mcu.get_printer().get_reactor()
@@ -100,6 +103,18 @@ class KlipperCartographerMcu(Mcu, KlipperStreamMcu):
         self.printer.register_event_handler("klippy:connect", self._handle_connect)
         self.printer.register_event_handler("klippy:shutdown", self._handle_shutdown)
         self.klipper_mcu.register_config_callback(self._initialize)
+
+        get_reconnect_event: Callable[[], str] | None = getattr(
+            self.klipper_mcu, "get_non_critical_reconnect_event_name", None
+        )
+        get_disconnect_event: Callable[[], str] | None = getattr(
+            self.klipper_mcu, "get_non_critical_disconnect_event_name", None
+        )
+        if get_reconnect_event is not None and get_disconnect_event is not None:
+            reconnect_event = get_reconnect_event()
+            disconnect_event = get_disconnect_event()
+            self.printer.register_event_handler(reconnect_event, self._handle_reconnect)  # pyright: ignore [reportCallIssue, reportArgumentType]
+            self.printer.register_event_handler(disconnect_event, self._handle_disconnect)  # pyright: ignore [reportCallIssue, reportArgumentType]
 
     @override
     def get_status(self, eventtime: float) -> dict[str, object]:
@@ -233,6 +248,24 @@ class KlipperCartographerMcu(Mcu, KlipperStreamMcu):
     def _handle_shutdown(self) -> None:
         if self._commands is not None:
             self.stop_streaming()
+
+    def register_reconnect_callback(self, callback: Callable[[], None]) -> None:
+        self._reconnect_callbacks.append(callback)
+
+    def _handle_reconnect(self) -> None:
+        logger.info("Cartographer MCU reconnected")
+        for callback in self._reconnect_callbacks:
+            try:
+                callback()
+            except Exception as e:
+                logger.exception("Error in reconnect callback")
+                self.printer.invoke_shutdown(f"Cartographer MCU reconnect failed: {e}")
+                return
+
+    def _handle_disconnect(self) -> None:
+        logger.warning("Cartographer MCU disconnected")
+        self._sensor_ready = False
+        self._stream.abort_all_sessions()
 
     def _handle_data(self, data: _RawData) -> None:
         """

--- a/src/cartographer/core.py
+++ b/src/cartographer/core.py
@@ -85,6 +85,9 @@ class PrinterCartographer:
         self.macros = self._create_macro_registrations(probe, toolhead, adapters)
 
     def ready_callback(self) -> None:
+        self.validate_and_load_models()
+
+    def validate_and_load_models(self) -> None:
         mcu_version = self.mcu.get_mcu_version()
         if mcu_version is not None:
             validate_and_remove_incompatible_models(self.config, mcu_version)

--- a/src/cartographer/extra.py
+++ b/src/cartographer/extra.py
@@ -27,6 +27,10 @@ def load_config(config: object) -> object:
 
     integrator.register_ready_callback(cartographer.ready_callback)
 
+    register_reconnect = getattr(adapters.mcu, "register_reconnect_callback", None)
+    if register_reconnect is not None:
+        register_reconnect(cartographer.validate_and_load_models)
+
     integrator_name = integrator.__class__.__name__
     logger.info("Loaded Cartographer3D Plugin version %s using %s", __version__, integrator_name)
 

--- a/src/cartographer/stream.py
+++ b/src/cartographer/stream.py
@@ -16,6 +16,8 @@ class Condition(Protocol):
 
 
 class Session(Generic[T]):
+    _aborted: bool = False
+
     def __init__(
         self,
         stream: Stream[T],
@@ -38,12 +40,23 @@ class Session(Generic[T]):
         self._condition.notify_all()
 
     def wait_for(self, condition: Callable[[list[T]], bool]):
-        """Waits until the given condition function returns True."""
-        self._condition.wait_for(lambda: condition(self.items))
+        """Waits until the given condition function returns True.
+
+        Raises RuntimeError if the session was aborted (e.g. MCU disconnect).
+        """
+        self._condition.wait_for(lambda: self._aborted or condition(self.items))
+        if self._aborted:
+            msg = "Cartographer MCU disconnected during session"
+            raise RuntimeError(msg)
 
     def get_items(self) -> list[T]:
         """Returns collected items after session ends."""
         return self.items
+
+    def abort(self) -> None:
+        """Abort this session; any waiter will wake and raise RuntimeError."""
+        self._aborted = True
+        self._condition.notify_all()
 
     def __enter__(self):
         return self  # Allows using `with session:`
@@ -85,6 +98,11 @@ class Stream(ABC, Generic[T]):
     def end_session(self, session: Session[T]):
         """Ends a session and removes it from active sessions."""
         self.sessions.discard(session)
+
+    def abort_all_sessions(self) -> None:
+        """Wake all waiting sessions so they detect abort and raise."""
+        for session in list(self.sessions):
+            session.abort()
 
     def register_callback(self, callback: Callable[[T], None]):
         """Registers a callback to the stream."""

--- a/tests/klipper/mcu/test_commands.py
+++ b/tests/klipper/mcu/test_commands.py
@@ -4,8 +4,6 @@ import sys
 from typing import TYPE_CHECKING
 from unittest.mock import Mock
 
-import pytest
-
 # Stub klipper modules not present in test environment
 if "mcu" not in sys.modules:
     sys.modules["mcu"] = Mock()
@@ -21,50 +19,36 @@ if TYPE_CHECKING:
     from pytest_mock import MockerFixture
 
 
-class TestCheckConnected:
-    """Tests for the _check_connected pre-flight guard."""
+def _make_commands(mocker: MockerFixture) -> tuple[KlipperCartographerCommands, Mock]:
+    mcu = mocker.MagicMock()
+    cmd_wrapper = mocker.Mock()
+    mcu.lookup_command.return_value = cmd_wrapper
+    mcu.alloc_command_queue.return_value = mocker.Mock()
+    commands = KlipperCartographerCommands(mcu)
+    commands.initialize()
+    return commands, cmd_wrapper
 
-    def _make_commands(self, mocker: MockerFixture, *, disconnected: bool) -> tuple[KlipperCartographerCommands, Mock]:
-        mcu = mocker.MagicMock()
-        mcu.non_critical_disconnected = disconnected
-        cmd_wrapper = mocker.Mock()
-        mcu.lookup_command.return_value = cmd_wrapper
-        mcu.alloc_command_queue.return_value = mocker.Mock()
-        commands = KlipperCartographerCommands(mcu)
-        commands.initialize()
-        return commands, cmd_wrapper
 
-    # --- send_stream_state ---
+class TestSendCommands:
+    """Smoke tests that each public send method dispatches via CommandWrapper.send."""
 
-    def test_send_stream_state_normal(self, mocker: MockerFixture) -> None:
-        commands, wrapper = self._make_commands(mocker, disconnected=False)
+    def test_send_stream_state_enable(self, mocker: MockerFixture) -> None:
+        commands, wrapper = _make_commands(mocker)
         commands.send_stream_state(enable=True)
         wrapper.send.assert_called_once_with([1])
 
-    def test_send_stream_state_disconnected_raises_runtime_error(self, mocker: MockerFixture) -> None:
-        commands, wrapper = self._make_commands(mocker, disconnected=True)
-        with pytest.raises(RuntimeError, match="disconnected"):
-            commands.send_stream_state(enable=True)
-        wrapper.send.assert_not_called()
+    def test_send_stream_state_disable(self, mocker: MockerFixture) -> None:
+        commands, wrapper = _make_commands(mocker)
+        commands.send_stream_state(enable=False)
+        wrapper.send.assert_called_once_with([0])
 
-    # --- send_threshold ---
-
-    def test_send_threshold_normal(self, mocker: MockerFixture) -> None:
-        commands, wrapper = self._make_commands(mocker, disconnected=False)
-        threshold = ThresholdCommand(trigger=100, untrigger=90)
-        commands.send_threshold(threshold)
+    def test_send_threshold(self, mocker: MockerFixture) -> None:
+        commands, wrapper = _make_commands(mocker)
+        commands.send_threshold(ThresholdCommand(trigger=100, untrigger=90))
         wrapper.send.assert_called_once_with([100, 90])
 
-    def test_send_threshold_disconnected_raises_runtime_error(self, mocker: MockerFixture) -> None:
-        commands, wrapper = self._make_commands(mocker, disconnected=True)
-        with pytest.raises(RuntimeError, match="disconnected"):
-            commands.send_threshold(ThresholdCommand(trigger=100, untrigger=90))
-        wrapper.send.assert_not_called()
-
-    # --- send_home ---
-
-    def test_send_home_normal(self, mocker: MockerFixture) -> None:
-        commands, wrapper = self._make_commands(mocker, disconnected=False)
+    def test_send_home(self, mocker: MockerFixture) -> None:
+        commands, wrapper = _make_commands(mocker)
         home_cmd = HomeCommand(
             trsync_oid=1,
             trigger_reason=2,
@@ -75,47 +59,7 @@ class TestCheckConnected:
         commands.send_home(home_cmd)
         wrapper.send.assert_called_once_with(list(home_cmd))
 
-    def test_send_home_disconnected_raises_runtime_error(self, mocker: MockerFixture) -> None:
-        commands, wrapper = self._make_commands(mocker, disconnected=True)
-        home_cmd = HomeCommand(
-            trsync_oid=1,
-            trigger_reason=2,
-            trigger_invert=0,
-            threshold=50,
-            trigger_method=TriggerMethod.SCAN,
-        )
-        with pytest.raises(RuntimeError, match="disconnected"):
-            commands.send_home(home_cmd)
-        wrapper.send.assert_not_called()
-
-    # --- send_stop_home ---
-
-    def test_send_stop_home_normal(self, mocker: MockerFixture) -> None:
-        commands, wrapper = self._make_commands(mocker, disconnected=False)
+    def test_send_stop_home(self, mocker: MockerFixture) -> None:
+        commands, wrapper = _make_commands(mocker)
         commands.send_stop_home()
         wrapper.send.assert_called_once_with()
-
-    def test_send_stop_home_disconnected_raises_runtime_error(self, mocker: MockerFixture) -> None:
-        commands, wrapper = self._make_commands(mocker, disconnected=True)
-        with pytest.raises(RuntimeError, match="disconnected"):
-            commands.send_stop_home()
-        wrapper.send.assert_not_called()
-
-    # --- missing attribute (stock Klipper) ---
-
-    def test_missing_attribute_treated_as_connected(self, mocker: MockerFixture) -> None:
-        """On stock Klipper, non_critical_disconnected is absent; getattr default is False."""
-        mcu = mocker.MagicMock(
-            spec=[
-                "alloc_command_queue",
-                "lookup_command",
-            ]
-        )
-        cmd_wrapper = mocker.Mock()
-        mcu.lookup_command.return_value = cmd_wrapper
-        mcu.alloc_command_queue.return_value = mocker.Mock()
-
-        commands = KlipperCartographerCommands(mcu)
-        commands.initialize()
-        commands.send_stream_state(enable=False)
-        cmd_wrapper.send.assert_called_once_with([0])

--- a/tests/klipper/mcu/test_commands.py
+++ b/tests/klipper/mcu/test_commands.py
@@ -1,0 +1,121 @@
+from __future__ import annotations
+
+import sys
+from typing import TYPE_CHECKING
+from unittest.mock import Mock
+
+import pytest
+
+# Stub klipper modules not present in test environment
+if "mcu" not in sys.modules:
+    sys.modules["mcu"] = Mock()
+
+from cartographer.adapters.klipper.mcu.commands import (
+    HomeCommand,
+    KlipperCartographerCommands,
+    ThresholdCommand,
+    TriggerMethod,
+)
+
+if TYPE_CHECKING:
+    from pytest_mock import MockerFixture
+
+
+class TestCheckConnected:
+    """Tests for the _check_connected pre-flight guard."""
+
+    def _make_commands(self, mocker: MockerFixture, *, disconnected: bool) -> tuple[KlipperCartographerCommands, Mock]:
+        mcu = mocker.MagicMock()
+        mcu.non_critical_disconnected = disconnected
+        cmd_wrapper = mocker.Mock()
+        mcu.lookup_command.return_value = cmd_wrapper
+        mcu.alloc_command_queue.return_value = mocker.Mock()
+        commands = KlipperCartographerCommands(mcu)
+        commands.initialize()
+        return commands, cmd_wrapper
+
+    # --- send_stream_state ---
+
+    def test_send_stream_state_normal(self, mocker: MockerFixture) -> None:
+        commands, wrapper = self._make_commands(mocker, disconnected=False)
+        commands.send_stream_state(enable=True)
+        wrapper.send.assert_called_once_with([1])
+
+    def test_send_stream_state_disconnected_raises_runtime_error(self, mocker: MockerFixture) -> None:
+        commands, wrapper = self._make_commands(mocker, disconnected=True)
+        with pytest.raises(RuntimeError, match="disconnected"):
+            commands.send_stream_state(enable=True)
+        wrapper.send.assert_not_called()
+
+    # --- send_threshold ---
+
+    def test_send_threshold_normal(self, mocker: MockerFixture) -> None:
+        commands, wrapper = self._make_commands(mocker, disconnected=False)
+        threshold = ThresholdCommand(trigger=100, untrigger=90)
+        commands.send_threshold(threshold)
+        wrapper.send.assert_called_once_with([100, 90])
+
+    def test_send_threshold_disconnected_raises_runtime_error(self, mocker: MockerFixture) -> None:
+        commands, wrapper = self._make_commands(mocker, disconnected=True)
+        with pytest.raises(RuntimeError, match="disconnected"):
+            commands.send_threshold(ThresholdCommand(trigger=100, untrigger=90))
+        wrapper.send.assert_not_called()
+
+    # --- send_home ---
+
+    def test_send_home_normal(self, mocker: MockerFixture) -> None:
+        commands, wrapper = self._make_commands(mocker, disconnected=False)
+        home_cmd = HomeCommand(
+            trsync_oid=1,
+            trigger_reason=2,
+            trigger_invert=0,
+            threshold=50,
+            trigger_method=TriggerMethod.SCAN,
+        )
+        commands.send_home(home_cmd)
+        wrapper.send.assert_called_once_with(list(home_cmd))
+
+    def test_send_home_disconnected_raises_runtime_error(self, mocker: MockerFixture) -> None:
+        commands, wrapper = self._make_commands(mocker, disconnected=True)
+        home_cmd = HomeCommand(
+            trsync_oid=1,
+            trigger_reason=2,
+            trigger_invert=0,
+            threshold=50,
+            trigger_method=TriggerMethod.SCAN,
+        )
+        with pytest.raises(RuntimeError, match="disconnected"):
+            commands.send_home(home_cmd)
+        wrapper.send.assert_not_called()
+
+    # --- send_stop_home ---
+
+    def test_send_stop_home_normal(self, mocker: MockerFixture) -> None:
+        commands, wrapper = self._make_commands(mocker, disconnected=False)
+        commands.send_stop_home()
+        wrapper.send.assert_called_once_with()
+
+    def test_send_stop_home_disconnected_raises_runtime_error(self, mocker: MockerFixture) -> None:
+        commands, wrapper = self._make_commands(mocker, disconnected=True)
+        with pytest.raises(RuntimeError, match="disconnected"):
+            commands.send_stop_home()
+        wrapper.send.assert_not_called()
+
+    # --- missing attribute (stock Klipper) ---
+
+    def test_missing_attribute_treated_as_connected(self, mocker: MockerFixture) -> None:
+        """On stock Klipper, non_critical_disconnected is absent; getattr default is False."""
+        mcu = mocker.MagicMock(
+            spec=[
+                "alloc_command_queue",
+                "lookup_command",
+            ]
+        )
+        cmd_wrapper = mocker.Mock()
+        mcu.lookup_command.return_value = cmd_wrapper
+        mcu.alloc_command_queue.return_value = mocker.Mock()
+
+        commands = KlipperCartographerCommands(mcu)
+        commands.initialize()
+        commands.send_stream_state(enable=False)
+        cmd_wrapper.send.assert_called_once_with([0])

--- a/tests/klipper/mcu/test_mcu_properties.py
+++ b/tests/klipper/mcu/test_mcu_properties.py
@@ -1,0 +1,74 @@
+from __future__ import annotations
+
+import sys
+from typing import TYPE_CHECKING
+from unittest.mock import Mock
+
+import pytest
+
+# Stub klipper modules not present in test environment
+for _name in ("mcu", "reactor", "configfile", "motion_report", "extras", "extras.thermistor", "greenlet"):
+    if _name not in sys.modules:
+        sys.modules[_name] = Mock()
+
+from cartographer.adapters.klipper.mcu.mcu import KlipperCartographerMcu  # noqa: E402
+
+if TYPE_CHECKING:
+    from pytest_mock import MockerFixture
+
+
+def _make_mcu(klipper_mcu: Mock, commands: object | None, constants: object | None) -> KlipperCartographerMcu:
+    """Build a bare KlipperCartographerMcu without running __init__."""
+    obj = object.__new__(KlipperCartographerMcu)
+    obj.klipper_mcu = klipper_mcu
+    obj._commands = commands  # pyright: ignore [reportAttributeAccessIssue, reportPrivateUsage]
+    obj._constants = constants  # pyright: ignore [reportAttributeAccessIssue, reportPrivateUsage]
+    return obj
+
+
+class TestCommandsProperty:
+    def test_returns_commands_when_connected(self, mocker: MockerFixture) -> None:
+        klipper_mcu = mocker.MagicMock()
+        klipper_mcu.non_critical_disconnected = False
+        commands = mocker.Mock()
+        obj = _make_mcu(klipper_mcu, commands=commands, constants=None)
+
+        assert obj.commands is commands
+
+    def test_raises_when_not_initialized(self, mocker: MockerFixture) -> None:
+        klipper_mcu = mocker.MagicMock()
+        obj = _make_mcu(klipper_mcu, commands=None, constants=None)
+
+        with pytest.raises(RuntimeError, match="not initialized"):
+            _ = obj.commands
+
+    def test_raises_when_disconnected(self, mocker: MockerFixture) -> None:
+        klipper_mcu = mocker.MagicMock()
+        klipper_mcu.non_critical_disconnected = True
+        commands = mocker.Mock()
+        obj = _make_mcu(klipper_mcu, commands=commands, constants=None)
+
+        with pytest.raises(RuntimeError, match="disconnected"):
+            _ = obj.commands
+
+    def test_works_on_stock_klipper_without_attribute(self, mocker: MockerFixture) -> None:
+        """Stock Klipper has no non_critical_disconnected attribute."""
+        klipper_mcu = mocker.MagicMock(spec=[])
+        commands = mocker.Mock()
+        obj = _make_mcu(klipper_mcu, commands=commands, constants=None)
+
+        assert obj.commands is commands
+
+
+class TestConstantsProperty:
+    def test_returns_constants_when_initialized(self, mocker: MockerFixture) -> None:
+        constants = mocker.Mock()
+        obj = _make_mcu(mocker.MagicMock(), commands=None, constants=constants)
+
+        assert obj.constants is constants
+
+    def test_raises_when_not_initialized(self, mocker: MockerFixture) -> None:
+        obj = _make_mcu(mocker.MagicMock(), commands=None, constants=None)
+
+        with pytest.raises(RuntimeError, match="not initialized"):
+            _ = obj.constants

--- a/tests/test_stream.py
+++ b/tests/test_stream.py
@@ -69,3 +69,48 @@ class TestStream:
 
         stream.end_session(session)
         worker.join()  # Ensure thread has finished before exiting
+
+
+class TestSessionAbort:
+    def test_session_abort_wakes_waiter_with_runtime_error(self, stream: Stream[object]) -> None:
+        """Aborting a session causes wait_for to raise RuntimeError."""
+        session = stream.start_session()
+
+        def abort_soon() -> None:
+            time.sleep(0.05)
+            session.abort()
+
+        worker = threading.Thread(target=abort_soon)
+        worker.start()
+
+        with pytest.raises(RuntimeError, match="disconnected"):
+            session.wait_for(lambda items: len(items) >= 100)  # never-true condition
+
+        worker.join()
+
+    def test_abort_already_set_raises_immediately(self, stream: Stream[object]) -> None:
+        """If abort() was called before wait_for, wait_for raises without blocking."""
+        session = stream.start_session()
+        session.abort()
+
+        with pytest.raises(RuntimeError, match="disconnected"):
+            session.wait_for(lambda items: False)
+
+
+class TestAbortAllSessions:
+    def test_stream_abort_all_sessions_aborts_each(self, stream: Stream[object]) -> None:
+        """abort_all_sessions aborts every active session."""
+        session_a = stream.start_session()
+        session_b = stream.start_session()
+
+        stream.abort_all_sessions()
+
+        with pytest.raises(RuntimeError):
+            session_a.wait_for(lambda items: False)
+
+        with pytest.raises(RuntimeError):
+            session_b.wait_for(lambda items: False)
+
+    def test_stream_abort_all_sessions_empty(self, stream: Stream[object]) -> None:
+        """abort_all_sessions on a stream with no sessions does not raise."""
+        stream.abort_all_sessions()  # Should not raise


### PR DESCRIPTION
## Summary

Adds support for Kalico's non-critical MCU reconnection lifecycle. When a Cartographer MCU configured as `is_non_critical` disconnects and reconnects at runtime, the plugin now re-initializes firmware constants, re-lookups commands, and re-validates/reloads models — without leaking resources or accumulating stale callbacks.

This builds on #472 (graceful startup when disconnected) to complete the reconnection story.

Fixes #473

## Decisions & callouts

- `_initialize` is now idempotent: `KlipperCartographerConstants` and `KlipperCartographerCommands` are constructed once (guarded by `is None`), but their `initialize()` methods are called on every `_initialize` to re-read firmware values and re-lookup commands.
- Kalico event registration uses `getattr` detection for `get_non_critical_reconnect_event_name` / `get_non_critical_disconnect_event_name`. Both must be present for handlers to register — this matches Kalico's API where both are always provided together.
- Reconnect callbacks are wrapped in `try/except` to prevent a failing callback from breaking Kalico's reconnection flow.
- `_register_data_response()` is called on every `_initialize`. This is safe because Klipper's `register_serial_response` replaces existing handlers rather than accumulating them.

## Testing

Install this branch for testing:

```
~/klippy-env/bin/pip install --no-cache-dir --force-reinstall "git+https://github.com/Cartographer3D/cartographer3d-plugin.git@feat/idempotent-initialize"
sudo systemctl restart klipper
```

- [x] Start with Cartographer MCU connected — everything should work normally (no regression)
- [x] With `is_non_critical = true`, disconnect and reconnect the Cartographer MCU — plugin should re-initialize and resume normal operation
- [x] Check klippy.log after reconnect — should see "Cartographer MCU reconnected" info message and successful model reloading
- [x] Disconnect the MCU — should see "Cartographer MCU disconnected" warning in klippy.log and probe operations should fail with clear errors

## Known issue

If the Cartographer MCU is disconnected, Klipper firmware is restarted, and *then* the MCU is plugged back in, Kalico's reactor crashes with `Failed automated reset of MCU 'cartographer'` raised from `non_critical_recon_event`. This is a Kalico-side bug — the timer callback at `klippy/mcu.py::non_critical_recon_event` does not catch the `error` raised by `recon_mcu()` / `_connect()`, so it escapes to `printer.run` and shuts klippy down. Tracked upstream as KalicoCrew/kalico#870.

The reverse order (disconnect → reconnect, no FW restart in between) works correctly with this PR.
