### PR TITLE
fix(scipy): detect incompatible scipy/numpy versions before calibration

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -19,7 +19,10 @@ homepage = "https://cartographer3d.com/"
 repository = "https://github.com/Cartographer3D/cartographer3d-plugin"
 
 [project.optional-dependencies]
-scipy = ["scipy~=1.9"]
+scipy = [
+  "scipy>=1.12; python_version>='3.9'",
+  "scipy>=1.9; python_version<'3.9'",
+]
 
 [dependency-groups]
 test = [

--- a/src/cartographer/lib/scipy_helpers.py
+++ b/src/cartographer/lib/scipy_helpers.py
@@ -1,6 +1,7 @@
 # pyright: reportExplicitAny=false, reportUnknownVariableType=false
 from __future__ import annotations
 
+from importlib import import_module
 from importlib.util import find_spec
 from typing import TYPE_CHECKING, Any, Callable
 
@@ -11,9 +12,40 @@ if TYPE_CHECKING:
     from scipy.interpolate import RBFInterpolator
 
 
+def _raise_if_scipy_unavailable(module: str, name: str) -> None:
+    """Private helper to check scipy module/name availability."""
+    if find_spec("scipy") is None:
+        msg = "scipy is required but is not installed."
+        raise RuntimeError(msg)
+    try:
+        mod = import_module(module)
+        getattr(mod, name)
+    except (ImportError, AttributeError) as e:
+        msg = (
+            "scipy is installed but failed to import "
+            "(possibly due to incompatible numpy version or broken install). "
+            f"{e!s}\nTry: pip install --upgrade scipy"
+        )
+        raise RuntimeError(msg) from None
+
+
+def raise_if_curve_fit_unavailable() -> None:
+    """Raise with clear error if scipy.optimize.curve_fit is unavailable."""
+    _raise_if_scipy_unavailable("scipy.optimize", "curve_fit")
+
+
+def raise_if_rbf_interpolator_unavailable() -> None:
+    """Raise with clear error if scipy.interpolate.RBFInterpolator is unavailable."""
+    _raise_if_scipy_unavailable("scipy.interpolate", "RBFInterpolator")
+
+
 def is_available() -> bool:
     """Return True if scipy is available."""
-    return find_spec("scipy") is not None
+    try:
+        raise_if_curve_fit_unavailable()
+        return True
+    except RuntimeError:
+        return False
 
 
 def curve_fit(
@@ -27,18 +59,31 @@ def curve_fit(
     xtol: float = 1e-8,
 ) -> tuple[NDArray[np.float_], NDArray[np.float_]]:
     """Wrapper for scipy.optimize.curve_fit, raises if unavailable."""
-    if not is_available():
-        msg = "scipy is required for curve fit, but is not installed."
-        raise RuntimeError(msg)
-    from scipy.optimize import curve_fit
+    raise_if_curve_fit_unavailable()
+    try:
+        from scipy.optimize import curve_fit as scipy_curve_fit
+    except (ImportError, AttributeError) as e:
+        msg = (
+            "scipy.optimize is installed but failed to import "
+            "(possibly due to incompatible numpy version or broken install). "
+            f"{e!s}\nTry: pip install --upgrade scipy"
+        )
+        raise RuntimeError(msg) from None
 
-    return curve_fit(f, xdata, ydata, bounds=bounds, maxfev=maxfev, ftol=ftol, xtol=xtol)
+    return scipy_curve_fit(f, xdata, ydata, bounds=bounds, maxfev=maxfev, ftol=ftol, xtol=xtol)
 
 
 def rbf_interpolator(y: NDArray[Any], d: NDArray[Any], *, neighbors: int, smoothing: float) -> RBFInterpolator:
-    if not is_available():
-        msg = "scipy is required for RBF interpolation, but is not installed."
-        raise RuntimeError(msg)
-    from scipy.interpolate import RBFInterpolator
+    """Wrapper for scipy.interpolate.RBFInterpolator, raises if unavailable."""
+    raise_if_rbf_interpolator_unavailable()
+    try:
+        from scipy.interpolate import RBFInterpolator
+    except (ImportError, AttributeError) as e:
+        msg = (
+            "scipy.interpolate is installed but failed to import "
+            "(possibly due to incompatible numpy version or broken install). "
+            f"{e!s}\nTry: pip install --upgrade scipy"
+        )
+        raise RuntimeError(msg) from None
 
     return RBFInterpolator(y, d, neighbors=neighbors, smoothing=smoothing)

--- a/src/cartographer/macros/bed_mesh/helpers.py
+++ b/src/cartographer/macros/bed_mesh/helpers.py
@@ -278,9 +278,7 @@ class CoordinateTransformer:
 
         # Interpolate missing values if scipy is available
         if np.any(mask):
-            if not scipy_helpers.is_available():
-                msg = "scipy is required for interpolation of faulty regions"
-                raise RuntimeError(msg)
+            scipy_helpers.raise_if_rbf_interpolator_unavailable()
             logger.info("Interpolating %d faulty points", np.sum(mask))
 
             # Use the same order as flattening the mask/grid

--- a/src/cartographer/macros/temperature_calibrate.py
+++ b/src/cartographer/macros/temperature_calibrate.py
@@ -64,9 +64,7 @@ class TemperatureCalibrateMacro(Macro):
 
     @override
     def run(self, params: MacroParams) -> None:
-        if not scipy_helpers.is_available():
-            msg = "scipy is required for temperature calibration, but is not installed"
-            raise RuntimeError(msg)
+        scipy_helpers.raise_if_curve_fit_unavailable()
 
         p = parse(TemperatureCalibrateParams, params)
 

--- a/tests/lib/test_scipy_helpers.py
+++ b/tests/lib/test_scipy_helpers.py
@@ -1,0 +1,85 @@
+from __future__ import annotations
+
+import sys
+from typing import TYPE_CHECKING
+from unittest.mock import patch
+
+import pytest
+
+from cartographer.lib.scipy_helpers import (
+    is_available,
+    raise_if_curve_fit_unavailable,
+    raise_if_rbf_interpolator_unavailable,
+)
+
+if TYPE_CHECKING:
+    from pytest_mock import MockerFixture
+
+
+class TestIsAvailable:
+    """Tests for is_available() function."""
+
+    def test_is_available_true(self) -> None:
+        """is_available() returns True when scipy is importable."""
+        result = is_available()
+        assert result is True
+
+    def test_is_available_false_not_installed(self) -> None:
+        """is_available() returns False when scipy.optimize is not importable."""
+        with patch.dict(sys.modules, {"scipy.optimize": None}):
+            result = is_available()
+        assert result is False
+
+    def test_is_available_false_import_error(self) -> None:
+        """is_available() returns False when scipy.optimize raises ImportError."""
+        with patch.dict(sys.modules, {"scipy.optimize": None}):
+            result = is_available()
+        assert result is False
+
+
+class TestRaiseIfCurveFitUnavailable:
+    """Tests for raise_if_curve_fit_unavailable() function."""
+
+    def test_not_installed(self, mocker: MockerFixture) -> None:
+        """raise_if_curve_fit_unavailable() raises RuntimeError with 'not installed' when find_spec returns None."""
+        _ = mocker.patch("cartographer.lib.scipy_helpers.find_spec", return_value=None)
+        with pytest.raises(RuntimeError, match="not installed"):
+            raise_if_curve_fit_unavailable()
+
+    def test_import_error(self, mocker: MockerFixture) -> None:
+        """raise_if_curve_fit_unavailable() raises RuntimeError with 'failed to import' when import fails."""
+        _ = mocker.patch("cartographer.lib.scipy_helpers.find_spec", return_value="mock_spec")
+        _ = mocker.patch(
+            "cartographer.lib.scipy_helpers.import_module",
+            side_effect=ImportError("no module"),
+        )
+        with pytest.raises(RuntimeError, match="failed to import"):
+            raise_if_curve_fit_unavailable()
+
+    def test_success(self) -> None:
+        """raise_if_curve_fit_unavailable() does not raise when scipy is available."""
+        raise_if_curve_fit_unavailable()
+
+
+class TestRaiseIfRbfInterpolatorUnavailable:
+    """Tests for raise_if_rbf_interpolator_unavailable() function."""
+
+    def test_not_installed(self, mocker: MockerFixture) -> None:
+        """Raises RuntimeError with 'not installed' when find_spec returns None."""
+        _ = mocker.patch("cartographer.lib.scipy_helpers.find_spec", return_value=None)
+        with pytest.raises(RuntimeError, match="not installed"):
+            raise_if_rbf_interpolator_unavailable()
+
+    def test_import_error(self, mocker: MockerFixture) -> None:
+        """raise_if_rbf_interpolator_unavailable() raises RuntimeError with 'failed to import' when import fails."""
+        _ = mocker.patch("cartographer.lib.scipy_helpers.find_spec", return_value="mock_spec")
+        _ = mocker.patch(
+            "cartographer.lib.scipy_helpers.import_module",
+            side_effect=ImportError("no module"),
+        )
+        with pytest.raises(RuntimeError, match="failed to import"):
+            raise_if_rbf_interpolator_unavailable()
+
+    def test_success(self) -> None:
+        """raise_if_rbf_interpolator_unavailable() does not raise when scipy is available."""
+        raise_if_rbf_interpolator_unavailable()

--- a/uv.lock
+++ b/uv.lock
@@ -64,7 +64,8 @@ typecheck = [
 
 [package.metadata]
 requires-dist = [
-    { name = "scipy", marker = "extra == 'scipy'", specifier = "~=1.9" },
+    { name = "scipy", marker = "python_full_version >= '3.9' and extra == 'scipy'", specifier = ">=1.12" },
+    { name = "scipy", marker = "python_full_version < '3.9' and extra == 'scipy'", specifier = ">=1.9" },
     { name = "typing-extensions", specifier = "~=4.12" },
 ]
 provides-extras = ["scipy"]


### PR DESCRIPTION
## Summary

Temperature calibration (`CARTOGRAPHER_CALIBRATE_TEMPERATURE`) crashes with `ImportError: cannot import name 'Inf' from 'numpy'` after completing all 3 sampling phases (3+ hours). Root cause: scipy <1.12 references `numpy.Inf` which was removed in NumPy 2.0. The `is_available()` guard only checked whether scipy existed on disk (`find_spec`), not whether it could actually be imported.

## Changes

1. **Early detection** — `is_available()` now attempts `from scipy.optimize import curve_fit` instead of `find_spec`. New `raise_if_unavailable()` distinguishes "not installed" from "incompatible versions" with an actionable error message. Both temperature calibration and bed mesh interpolation use it.
2. **Dependency constraint** — scipy optional dep uses Python version markers: `>=1.12` on Python 3.9+ (works with both NumPy 1.22+ and NumPy 2.0+), `>=1.9` on Python <3.9 (where NumPy 2.0 can't exist).
3. **Defense-in-depth** — `curve_fit()` and `rbf_interpolator()` wrappers catch `(ImportError, AttributeError)` instead of just `ImportError`, handling Python 3.8 scipy lazy-loading edge cases.

## Behavior changes

- `is_available()` is stricter: returns `False` for broken/incompatible scipy (previously returned `True` if the file existed on disk).
- Temperature calibration fails immediately with a clear message instead of after 3+ hours of data collection.
- Bed mesh faulty-point interpolation fails with a clear message instead of an opaque scipy/numpy traceback. (This check remains conditional — scipy is only required when faulty points need interpolation, so meshes without faulty points still work without scipy.)
- `pyproject.toml` raises the scipy floor to 1.12 on Python 3.9+. Existing installs are unaffected; new installs get a compatible version.

## Decisions & callouts

- `raise_if_unavailable()` probes `from scipy.optimize import curve_fit` (not just top-level `import scipy`) because scipy uses lazy submodule loading — the top-level import can succeed even when submodules would fail with the numpy.Inf error.
- Error messages are intentionally broad ("possibly due to incompatible numpy version or broken install") rather than assuming numpy is always the cause.
- scipy 1.12 is the minimum on Python 3.9+ because it's the first version with NumPy 2.0 support. It still works with NumPy 1.22+, so both numpy generations are covered.