### PR TITLE
fix: improve bed mesh scan robustness

### DIFF
--- a/src/cartographer/adapters/klipper/mcu/mcu.py
+++ b/src/cartographer/adapters/klipper/mcu/mcu.py
@@ -347,7 +347,7 @@ class KlipperCartographerMcu(Mcu, KlipperStreamMcu):
         if len(self._stream.sessions) > 0:
             self.klipper_mcu.get_printer().invoke_shutdown(error % {"count": count})
 
-    def get_requested_position(self, time: float) -> Position | None:
+    def get_requested_position(self, time: float) -> Position:
         """
         Get the requested position at a given time.
 
@@ -361,8 +361,8 @@ class KlipperCartographerMcu(Mcu, KlipperStreamMcu):
 
         Returns:
         --------
-        Position | None
-            The position at the given time, or None if unavailable.
+        Position
+            The position at the given time.
         """
         kinematics = self.kinematics
         stepper_pos = {

--- a/src/cartographer/macros/bed_mesh/helpers.py
+++ b/src/cartographer/macros/bed_mesh/helpers.py
@@ -122,7 +122,7 @@ class SampleProcessor:
         ]
 
         for x, y, sample in sample_points:
-            if not self.grid.contains_point((x, y)):
+            if not self.grid.contains_point((x, y), epsilon=self.max_distance):
                 continue
 
             j, i = self.grid.point_to_grid_index((x, y))

--- a/src/cartographer/macros/bed_mesh/scan_mesh.py
+++ b/src/cartographer/macros/bed_mesh/scan_mesh.py
@@ -322,11 +322,35 @@ class BedMeshCalibrateMacro(Macro, SupportsFallbackMacro):
         """Convert grid results to Position objects."""
         positions: list[Position] = []
 
+        total_samples = sum(r.sample_count for r in results)
+        invalid_points = [(r.point, r.sample_count) for r in results if not isfinite(r.z)]
+        sparse_points = [(r.point, r.sample_count) for r in results if isfinite(r.z) and r.sample_count < 3]
+
+        if invalid_points:
+            invalid_list = ", ".join(f"({p[0]:.2f},{p[1]:.2f}) samples={n}" for p, n in invalid_points)
+            lines = [
+                f"Mesh scan failed: {len(invalid_points)}/{len(results)} grid points have no valid samples.",
+                f"Total samples collected: {total_samples}.",
+                f"Invalid grid points: {invalid_list}.",
+            ]
+            if sparse_points:
+                sparse_list = ", ".join(f"({p[0]:.2f},{p[1]:.2f})={n}" for p, n in sparse_points)
+                lines.append(f"Sparse grid points (<3 samples): {sparse_list}.")
+            msg = " ".join(lines)
+            logger.error(msg)
+            raise RuntimeError(msg)
+
+        if sparse_points:
+            sparse_list = ", ".join(f"({p[0]:.2f},{p[1]:.2f})={n}" for p, n in sparse_points)
+            logger.warning(
+                "Mesh scan: %d/%d grid points have fewer than 3 samples: %s",
+                len(sparse_points),
+                len(results),
+                sparse_list,
+            )
+
         for result in results:
             rx, ry = result.point
-            if not isfinite(result.z):
-                msg = f"Grid point ({rx:.2f},{ry:.2f}) has no valid samples"
-                raise RuntimeError(msg)
 
             # Calculate compensated height
             z = height - result.z


### PR DESCRIPTION
## Summary

Addresses the "Grid Point has no valid sample" error that users hit during bed mesh calibration at higher speeds. The root cause is an overly tight boundary filter that creates an asymmetric capture zone for grid points at the mesh edges.

## Changes

- **Relax `contains_point` pre-filter** (`helpers.py`) — the boundary check used a 0.01mm epsilon while the subsequent distance check used 1.0mm, creating an asymmetric capture zone for boundary grid points. Now uses `epsilon=max_distance` so boundary and interior points have equal capture radius.
- **Diagnostic logging** (`scan_mesh.py`) — when grid points have invalid or too few samples, logs a single diagnostic message with total samples, affected grid points, and their coordinates. Makes the failure actionable instead of opaque.

## Decisions & callouts

- The `contains_point` epsilon change means samples slightly outside the grid boundary (up to `max_distance` = 1.0mm) can now contribute to boundary grid points. This matches how beacon handles it — they use index bounds checking without an epsilon pre-filter.
- The validation now uses `isfinite(r.z)` to catch both NaN (no samples) and inf (bad distance conversion) in one pass.