### PR TITLE
fix(mcu): reduce sample processing delay during active streaming

### DIFF
--- a/src/cartographer/adapters/klipper/mcu/async_processor.py
+++ b/src/cartographer/adapters/klipper/mcu/async_processor.py
@@ -29,9 +29,13 @@ class AsyncProcessor(Generic[T]):
     """
     Process items asynchronously on the main reactor thread.
 
-    This class queues items received from background threads and schedules
-    processing on the main reactor thread using register_async_callback.
-    This ensures thread-safe access to shared state during processing.
+    Items received from background threads are queued and processed on
+    the main reactor thread via register_async_callback.
+
+    By default, items are batched for up to ``BATCH_INTERVAL`` seconds
+    to reduce reactor wake-ups. When immediate mode is enabled, items
+    are dispatched without delay so that position lookups happen as
+    close to the sample time as possible.
 
     Parameters:
     -----------
@@ -50,14 +54,31 @@ class AsyncProcessor(Generic[T]):
         self._process_fn = process_fn
         self._pending_items: list[T] = []
         self._processing_scheduled = False
+        self._immediate = False
         self._lock = threading.Lock()
+
+    def set_immediate(self, enabled: bool) -> None:
+        """
+        Enable or disable immediate dispatch mode.
+
+        When enabled, items are dispatched to the reactor without delay
+        instead of waiting for the batch interval. Use during streaming
+        sessions where position accuracy matters.
+        """
+        with self._lock:
+            self._immediate = enabled
+            # Schedule immediate flush for any pending items — even if
+            # a batched callback is already pending, this ensures items
+            # don't wait for the full batch interval.
+            if enabled and self._pending_items:
+                self._processing_scheduled = True
+                self._reactor.register_async_callback(self._process_pending_items)
 
     def queue_item(self, item: T) -> None:
         """
         Queue an item for processing on the main reactor thread.
 
         This method is thread-safe and can be called from any thread.
-        It queues the item and schedules processing if not already scheduled.
 
         Parameters:
         -----------
@@ -66,11 +87,13 @@ class AsyncProcessor(Generic[T]):
         """
         with self._lock:
             self._pending_items.append(item)
-            # Schedule processing on main thread if not already scheduled
             if not self._processing_scheduled:
-                waketime = self._reactor.monotonic() + BATCH_INTERVAL
                 self._processing_scheduled = True
-                self._reactor.register_async_callback(self._process_pending_items, waketime=waketime)
+                if self._immediate:
+                    self._reactor.register_async_callback(self._process_pending_items)
+                else:
+                    waketime = self._reactor.monotonic() + BATCH_INTERVAL
+                    self._reactor.register_async_callback(self._process_pending_items, waketime=waketime)
 
     def _process_pending_items(self, eventtime: float) -> None:
         """

--- a/src/cartographer/adapters/klipper/mcu/mcu.py
+++ b/src/cartographer/adapters/klipper/mcu/mcu.py
@@ -224,9 +224,11 @@ class KlipperCartographerMcu(Mcu, KlipperStreamMcu):
     @override
     def start_streaming(self) -> None:
         self.commands.send_stream_state(enable=True)
+        self._async_processor.set_immediate(True)
 
     @override
     def stop_streaming(self) -> None:
+        self._async_processor.set_immediate(False)
         self.commands.send_stream_state(enable=False)
 
     @override

--- a/tests/klipper/mcu/test_async_processor.py
+++ b/tests/klipper/mcu/test_async_processor.py
@@ -6,7 +6,7 @@ from unittest.mock import MagicMock
 
 import pytest
 
-from cartographer.adapters.klipper.mcu.async_processor import AsyncProcessor
+from cartographer.adapters.klipper.mcu.async_processor import BATCH_INTERVAL, AsyncProcessor
 
 if TYPE_CHECKING:
     from collections.abc import Callable
@@ -353,3 +353,102 @@ class TestAsyncProcessorEdgeCases:
 
         # Don't queue anything
         assert len(reactor.callbacks) == 0
+
+
+class TestAsyncProcessorImmediateMode:
+    """Test immediate dispatch mode."""
+
+    def test_normal_mode_uses_waketime(self) -> None:
+        """In normal mode, callback is scheduled with a waketime delay."""
+        mock_reactor = MagicMock()
+        mock_reactor.monotonic.return_value = 100.0
+        processor = AsyncProcessor[int](mock_reactor, lambda _: None)
+
+        processor.queue_item(1)
+
+        mock_reactor.register_async_callback.assert_called_once()
+        _, kwargs = mock_reactor.register_async_callback.call_args
+        assert kwargs["waketime"] == pytest.approx(100.0 + BATCH_INTERVAL)  # pyright: ignore[reportUnknownMemberType]
+
+    def test_immediate_mode_skips_waketime(self) -> None:
+        """In immediate mode, callback is scheduled without waketime."""
+        mock_reactor = MagicMock()
+        processor = AsyncProcessor[int](mock_reactor, lambda _: None)
+        processor.set_immediate(True)
+
+        processor.queue_item(1)
+
+        mock_reactor.register_async_callback.assert_called_once()
+        _, kwargs = mock_reactor.register_async_callback.call_args
+        assert "waketime" not in kwargs
+
+    def test_set_immediate_flushes_pending_items(self) -> None:
+        """Enabling immediate mode flushes items pending in the batch window."""
+        reactor = FakeReactor()
+        collector = ProcessedItemsCollector()
+        processor = AsyncProcessor[int](reactor, collector.process)
+
+        # Queue in normal mode
+        processor.queue_item(1)
+        processor.queue_item(2)
+        reactor.run_pending_callbacks()
+        assert collector.items == [1, 2]
+
+        # Simulate items queued but batched callback not yet fired
+        processor.queue_item(3)
+        reactor.callbacks.clear()
+        processor._processing_scheduled = False  # noqa: SLF001  # pyright: ignore[reportPrivateUsage]
+
+        # Enable immediate -- should schedule flush for pending item
+        processor.set_immediate(True)
+        assert len(reactor.callbacks) == 1
+        reactor.run_pending_callbacks()
+        assert collector.items == [1, 2, 3]
+
+    def test_set_immediate_no_flush_when_empty(self) -> None:
+        """Enabling immediate with no pending items does not schedule."""
+        reactor = FakeReactor()
+        processor = AsyncProcessor[int](reactor, lambda _: None)
+
+        processor.set_immediate(True)
+        assert len(reactor.callbacks) == 0
+
+    def test_disabling_immediate_resumes_batching(self) -> None:
+        """After disabling immediate mode, items are batched again."""
+        mock_reactor = MagicMock()
+        mock_reactor.monotonic.return_value = 0.0
+        processor = AsyncProcessor[int](mock_reactor, lambda _: None)
+
+        processor.set_immediate(True)
+        processor.queue_item(1)
+        _, kwargs = mock_reactor.register_async_callback.call_args
+        assert "waketime" not in kwargs
+
+        # Process pending so flag resets
+        callback = mock_reactor.register_async_callback.call_args[0][0]
+        callback(0.0)
+
+        # Disable -- back to batched
+        processor.set_immediate(False)
+        processor.queue_item(2)
+        _, kwargs = mock_reactor.register_async_callback.call_args
+        assert "waketime" in kwargs
+
+    def test_set_immediate_promotes_pending_batched_callback(self) -> None:
+        """Enabling immediate mode flushes items even when a batched callback is already scheduled."""
+        reactor = FakeReactor()
+        collector = ProcessedItemsCollector()
+        processor = AsyncProcessor[int](reactor, collector.process)
+
+        # Queue item in normal mode — a batched callback is now scheduled
+        processor.queue_item(1)
+        assert len(reactor.callbacks) == 1
+
+        # Enable immediate while the batched callback is still pending.
+        # This should schedule an additional immediate callback.
+        processor.set_immediate(True)
+        assert len(reactor.callbacks) == 2
+
+        # Run callbacks — both fire, but second finds nothing
+        reactor.run_pending_callbacks()
+        assert collector.items == [1]


### PR DESCRIPTION
## Summary

The `AsyncProcessor` batches MCU samples with a 100ms delay before processing on the reactor thread. During active streaming (mesh scanning, probing), this delay risks stale step history when looking up stepper positions. During idle streaming (status, API dump), the delay is fine and reduces reactor wake-ups.

Adds `set_immediate(bool)` to `AsyncProcessor`. MCU `start_streaming`/`stop_streaming` toggle it so position lookups happen as close to sample time as possible during active sessions.

## Decisions & callouts

- The `BATCH_INTERVAL` (0.1s) is unchanged for idle streaming. Only active streaming sessions get immediate dispatch.
- `set_immediate(True)` schedules an immediate callback even if a batched callback is already pending. The duplicate callback is harmless — it finds nothing to process.