### PR TITLE
fix(mcu): correct sensor frequency divisor for >=100 MHz MCUs

### DIFF
--- a/src/cartographer/config/model_validator.py
+++ b/src/cartographer/config/model_validator.py
@@ -4,7 +4,7 @@ import logging
 import re
 from typing import TYPE_CHECKING
 
-MINIMUM_SCAN_MODEL_VERSION = (1, 0, 0)
+MINIMUM_SCAN_MODEL_VERSION = (1, 5, 3)
 MINIMUM_TOUCH_MODEL_VERSION = (1, 1, 0)
 
 if TYPE_CHECKING:

--- a/src/cartographer/mcu/constants.py
+++ b/src/cartographer/mcu/constants.py
@@ -80,7 +80,7 @@ class CartographerConstants:
             return clock_frequency
         if clock_frequency < 100e6:
             return clock_frequency / 2
-        return clock_frequency / 6
+        return clock_frequency / 8
 
     def count_to_frequency(self, count: int) -> float:
         return count * self._sensor_frequency / (2**28)


### PR DESCRIPTION
## Summary

The `_clock_to_sensor_frequency` heuristic divided by 6 for MCUs with clock >=100 MHz, which was an STM32F4 assumption. The actual timer prescaler on the G431 at 170 MHz produces a divisor of 8 (`gpio_pwm_setup` with `cycle_time=8`), so frequency calculations were off by ~33%.

Bumps `MINIMUM_SCAN_MODEL_VERSION` to `1.5.3` to force recalibration of scan models, as they were calibrated with incorrect frequency values.