### PR TITLE
revert: "fix(mcu): correct sensor frequency divisor for >=100 MHz MCUs (#483)"

### DIFF
--- a/src/cartographer/config/model_validator.py
+++ b/src/cartographer/config/model_validator.py
@@ -4,7 +4,7 @@ import logging
 import re
 from typing import TYPE_CHECKING
 
-MINIMUM_SCAN_MODEL_VERSION = (1, 5, 3)
+MINIMUM_SCAN_MODEL_VERSION = (1, 0, 0)
 MINIMUM_TOUCH_MODEL_VERSION = (1, 1, 0)
 
 if TYPE_CHECKING:

--- a/src/cartographer/mcu/constants.py
+++ b/src/cartographer/mcu/constants.py
@@ -80,7 +80,7 @@ class CartographerConstants:
             return clock_frequency
         if clock_frequency < 100e6:
             return clock_frequency / 2
-        return clock_frequency / 8
+        return clock_frequency / 6
 
     def count_to_frequency(self, count: int) -> float:
         return count * self._sensor_frequency / (2**28)


### PR DESCRIPTION
## Summary

Reverts #483. The divisor of 6 was correct for existing firmware. The model version bump was also unnecessary since the firmware version check already handles recalibration when `CARTOGRAPHER_SENSOR_FREQ_DIVISOR` is added.