### PR TITLE
fix(mcu): drop samples with negative print_time during non-critical reconnect

### DIFF
--- a/src/cartographer/mcu/mcu.py
+++ b/src/cartographer/mcu/mcu.py
@@ -270,6 +270,8 @@ class CartographerMcu(Mcu, CartographerStreamMcu):
         count = data["data"]
         clock = self._platform.clock32_to_clock64(data["clock"])
         time = self._platform.clock_to_print_time(clock)
+        if time < 0:
+            return
 
         frequency = self.constants.count_to_frequency(count)
         temperature = self.constants.calculate_temperature(data["temp"])


### PR DESCRIPTION
When a Kalico non-critical MCU disconnects, `_clocksync.disconnect()` resets the clock state. Samples already queued in the async processor are then processed with a clock that translates to a negative `print_time`, which is passed to `stepper.get_past_mcu_position()` and crashes with:

    OverflowError: can't convert negative number to unsigned

at `ffi_lib.stepcompress_find_past_position`. The async processor catches the exception and logs it, so the printer recovers, but every disconnect spams the console with tracebacks until reconnect completes.

Drop samples whose translated time is negative so they're discarded silently rather than triggering the FFI overflow.


Example traceback:

```
// mcu: 'cartographer' disconnected!
!! Error processing queued item: can't convert negative number to unsigned
Traceback (most recent call last):
  File ".../cartographer/mcu/async_processor.py", line 121, in _process_pending_items
    self._process_fn(item)
  File ".../cartographer/mcu/mcu.py", line 276, in _process_raw_data
    position = self._platform.get_requested_position(time)
  File ".../cartographer/adapters/klipper_like/mcu_platform.py", line 125, in get_requested_position
    stepper.get_name(): stepper.mcu_to_commanded_position(stepper.get_past_mcu_position(print_time))
  File "/.../klipper/klippy/stepper.py", line 255, in get_past_mcu_position
    pos = ffi_lib.stepcompress_find_past_position(self._stepqueue, clock)
OverflowError: can't convert negative number to unsigned
[same traceback repeats 3x more]
// mcu: 'cartographer' reconnected!
```

---
