### PR TITLE
chore: add perf label and changelog category

### DIFF
--- a/.github/auto-label-config.json
+++ b/.github/auto-label-config.json
@@ -4,12 +4,14 @@
     "enhancement",
     "chore",
     "breaking change",
-    "ignore-for-release"
+    "ignore-for-release",
+    "performance"
   ],
   "titleMappings": {
     "fix": "fix",
     "feat": "enhancement",
-    "chore": "chore"
+    "chore": "chore",
+    "perf": "performance"
   },
   "releaseRelevantPaths": ["^src/", "^uv\\.lock$"],
   "breakingChangeIndicator": "!",

--- a/.github/release.yml
+++ b/.github/release.yml
@@ -12,6 +12,9 @@ changelog:
     - title: 🐛 Squashed Bugs
       labels:
         - fix
+    - title: ⚡ Performance Improvements
+      labels:
+        - performance
     - title: 🧰 Other Changes
       labels:
         - "*"


### PR DESCRIPTION
Add `perf` as a recognized conventional-commit prefix so performance PRs (like #487) get labeled and appear under ⚡ Performance in release notes.