### PR TITLE
fix(coil): expose sensor for TEMPERATURE_WAIT macro

### DIFF
--- a/src/cartographer/adapters/klipper_like/integrator.py
+++ b/src/cartographer/adapters/klipper_like/integrator.py
@@ -31,6 +31,20 @@ if TYPE_CHECKING:
 logger = logging.getLogger(__name__)
 
 
+@final
+class _SensorConfigShim:
+    """Minimal shim satisfying heaters.register_sensor(config, ...) interface."""
+
+    def __init__(self, name: str) -> None:
+        self._name = name
+
+    def get_name(self) -> str:
+        return self._name
+
+    def get(self, _option: str, default: str | None = None, **_kw: object) -> str | None:
+        return default
+
+
 class KlipperLikeAdapters(Protocol):
     mcu: CartographerMcu
     printer: Printer
@@ -81,7 +95,7 @@ class KlipperLikeIntegrator(Integrator, ABC):
 
         object_name = f"temperature_sensor {sensor.name}"
         self._printer.add_object(object_name, sensor)
-        pheaters.available_sensors.append(object_name)
+        pheaters.register_sensor(_SensorConfigShim(object_name), sensor)  # pyright: ignore[reportArgumentType]  # shim satisfies runtime interface
 
     @override
     def register_ready_callback(self, callback: Callable[[], None]) -> None:


### PR DESCRIPTION
## Summary

The coil temperature sensor was registered by manually appending to `pheaters.available_sensors`, bypassing `pheaters.register_sensor()`. On Klipper, `register_sensor()` also registers a `TEMPERATURE_WAIT` mux command — without it, `TEMPERATURE_WAIT SENSOR="temperature_sensor cartographer_coil"` fails with *"not valid for SENSOR"*.

This was not an issue on Kalico, where `TEMPERATURE_WAIT` is a regular command that validates against the `available_sensors` list at runtime.

The fix introduces a minimal config shim to satisfy `register_sensor(config, sensor)` and works correctly on both Klipper and Kalico.

Fixes #477

## Install command

```
~/klippy-env/bin/pip install --no-cache-dir --force-reinstall "git+https://github.com/Cartographer3D/cartographer3d-plugin.git@fix/477-coil-temp-sensor"
sudo systemctl restart klipper
```

## Manual testing

- [x] On Klipper: run `TEMPERATURE_WAIT SENSOR="temperature_sensor cartographer_coil" MINIMUM=40` — should wait without error
- [x] Verify the coil temperature sensor still appears in Mainsail/Fluidd UI
- [x] On Kalico: confirm no regression — sensor still visible and `TEMPERATURE_WAIT` still works