### PR TITLE
fix(mesh): replace deprecated np.cross on 2D vectors

### DIFF
--- a/src/cartographer/macros/bed_mesh/paths/snake_path.py
+++ b/src/cartographer/macros/bed_mesh/paths/snake_path.py
@@ -82,7 +82,7 @@ def u_turn(start: Point, end: Point, entry_dir: Vec, radius: float) -> Iterator[
     # Determine if the turn is CCW or CW based on 2D cross product
     # We'll assume a horizontal travel: if moving left to right, then back right to left
     # Then the perpendicular should flip for the reverse direction
-    turn_ccw = bool(np.cross(entry_dir, turn_dir) > 0)  # flip depending on entry direction
+    turn_ccw = bool(entry_dir[0] * turn_dir[1] - entry_dir[1] * turn_dir[0] > 0)  # 2D cross product
     turn_angle = 90 if turn_ccw else -90
 
     entry_perp = perpendicular(entry_dir, ccw=turn_ccw)


### PR DESCRIPTION
## Summary

NumPy 2.0 deprecated `np.cross` on 2D arrays. This replaces the single call site with an inline 2D cross product (`a[0]*b[1] - a[1]*b[0]`), eliminating 58 test warnings.