### PR TITLE
feat: add opt-in telemetry

### DIFF
--- a/.github/workflows/delivery.yml
+++ b/.github/workflows/delivery.yml
@@ -22,6 +22,7 @@ jobs:
         env:
           GIT_VERSION: ${{ github.ref_name }}
           COMMIT_SHA: ${{ github.sha }}
+          BETTERSTACK_SOURCE_TOKEN: ${{ secrets.BETTERSTACK_SOURCE_TOKEN }}
       - name: Store the distribution packages
         uses: actions/upload-artifact@v4
         with:

--- a/.gitignore
+++ b/.gitignore
@@ -12,3 +12,4 @@ dist/
 .tox/
 junit*.xml
 release_info
+src/cartographer/telemetry/_token.py

--- a/TELEMETRY.md
+++ b/TELEMETRY.md
@@ -1,0 +1,92 @@
+# Telemetry
+
+Cartographer3D collects anonymous usage telemetry to help us understand how the
+plugin is used, prioritise development, and catch compatibility issues early.
+
+**Telemetry is opt-in and disabled by default.**
+
+## Opting in
+
+Add to your `printer.cfg`:
+
+```ini
+[cartographer]
+telemetry: True
+```
+
+## What we collect
+
+### Startup event (sent once per boot)
+
+| Field | Example | Purpose |
+|-------|---------|---------|
+| `anonymous_id` | `a1b2c3d4-...` | Persistent random UUID — not linked to any account or identity |
+| `plugin_version` | `1.2.0` | Track adoption of new releases |
+| `environment` | `klipper` / `kalico` | Know which runtime to prioritise |
+| `python_version` | `3.11.2` | Decide when to drop old Python support |
+| `os_platform` | `Linux-6.1.0-aarch64` | Understand host hardware |
+| `os_arch` | `aarch64` | Architecture distribution |
+| `mcu_version` | `v0.12.0-xxx` | Firmware version spread |
+| `config.general` | offsets, speeds, backlash | Whether defaults are appropriate |
+| `config.scan` | samples, probe_speed | Feature usage |
+| `config.touch` | samples, max_samples, retract_distance | Feature usage |
+| `config.bed_mesh` | probe_count, mesh_min/max, zero_reference_position | Typical bed configurations |
+| `config.coil` | `has_calibration: true/false` | Temperature compensation adoption |
+| `bed_size` | `{"min": [35, 6], "max": [315, 315]}` | Bed size distribution |
+| `calibration_summary` | model counts, has_temperature_calibration | Calibration feature usage |
+
+### Calibration events (sent after successful calibration)
+
+**Scan calibration:**
+
+| Field | Example |
+|-------|---------|
+| `calibration_type` | `"scan"` |
+| `method` | `"touch"` or `"manual"` |
+| `mcu_version` | `v0.12.0-xxx` |
+
+**Touch calibration:**
+
+| Field | Example |
+|-------|---------|
+| `calibration_type` | `"touch"` |
+| `threshold` | `2500` |
+| `speed` | `2` |
+| `median_range` | `0.003` |
+
+**Temperature calibration:**
+
+| Field | Example |
+|-------|---------|
+| `calibration_type` | `"temperature"` |
+| `mcu_version` | `v0.12.0-xxx` |
+
+## What we do NOT collect
+
+- No IP addresses are stored server-side
+- No file paths or hostnames
+- No print data or gcode
+- No personal information of any kind
+- No raw calibration coefficients or mesh data
+
+## How it works
+
+- Events are sent via HTTPS to [BetterStack Logs](https://betterstack.com/logs)
+- All network calls happen in background threads — telemetry never blocks printing
+- If sending fails (network down, timeout), the event is silently dropped
+- The anonymous ID is stored in `~/.cartographer3d/telemetry_id`
+
+## Opting out
+
+Remove or set to `False`:
+
+```ini
+[cartographer]
+telemetry: False
+```
+
+Delete your anonymous ID:
+
+```bash
+rm ~/.cartographer3d/telemetry_id
+```

--- a/hatch_build.py
+++ b/hatch_build.py
@@ -93,7 +93,21 @@ class CustomBuildHook(BuildHookInterface[BuilderConfig]):
 
         build_data["extra_metadata"][str(out_file)] = "release_info"
 
+        self._inject_telemetry_token()
+
+    def _inject_telemetry_token(self) -> None:
+        """Generate the telemetry token module from environment.
+
+        Reads ``BETTERSTACK_SOURCE_TOKEN``.  Produces an empty token for
+        local builds so the build never fails — telemetry simply won't send.
+        """
+        token = os.getenv("BETTERSTACK_SOURCE_TOKEN", "")
+        out = Path(self.root, "src", "cartographer", "telemetry", "_token.py")
+        _ = out.write_text(f'TOKEN = "{token}"\n')
+
     @override
     def clean(self, versions: list[str]) -> None:
         out_file = Path(self.root, "release_info")
         out_file.unlink(missing_ok=True)
+        token_file = Path(self.root, "src", "cartographer", "telemetry", "_token.py")
+        token_file.unlink(missing_ok=True)

--- a/src/cartographer/adapters/kalico/adapters.py
+++ b/src/cartographer/adapters/kalico/adapters.py
@@ -24,6 +24,8 @@ logger = logging.getLogger(__name__)
 
 @final
 class KalicoAdapters(Adapters):
+    environment = "kalico"
+
     def __init__(self, config: KlipperConfigWrapper) -> None:
         self.printer = config.get_printer()
         self.scheduler = KlipperScheduler(self.printer.get_reactor())

--- a/src/cartographer/adapters/klipper/adapters.py
+++ b/src/cartographer/adapters/klipper/adapters.py
@@ -24,6 +24,8 @@ logger = logging.getLogger(__name__)
 
 @final
 class KlipperAdapters(Adapters):
+    environment = "klipper"
+
     def __init__(self, config: KlipperConfigWrapper) -> None:
         self.printer = config.get_printer()
         self.scheduler = KlipperScheduler(self.printer.get_reactor())

--- a/src/cartographer/core.py
+++ b/src/cartographer/core.py
@@ -9,6 +9,7 @@ from cartographer.coil.temperature_compensation import (
     CoilTemperatureCompensationModel,
 )
 from cartographer.config.model_validator import validate_and_remove_incompatible_models
+from cartographer.events import EventBus
 from cartographer.macros.axis_twist_compensation import (
     AxisTwistCompensationMacro,
 )
@@ -30,13 +31,15 @@ from cartographer.macros.scan import ScanAccuracyMacro
 from cartographer.macros.scan_calibrate import (
     DEFAULT_SCAN_MODEL_NAME,
     ScanCalibrateMacro,
+    ScanCalibrationEvent,
 )
 from cartographer.macros.stream import StreamMacro
-from cartographer.macros.temperature_calibrate import TemperatureCalibrateMacro
+from cartographer.macros.temperature_calibrate import TemperatureCalibrateMacro, TemperatureCalibrationEvent
 from cartographer.macros.touch import (
     DEFAULT_TOUCH_MODEL_NAME,
     TouchAccuracyMacro,
     TouchCalibrateMacro,
+    TouchCalibrationEvent,
     TouchHomeMacro,
     TouchProbeMacro,
 )
@@ -44,6 +47,8 @@ from cartographer.probe.probe import Probe
 from cartographer.probe.scan_mode import ScanMode, ScanModeConfiguration
 from cartographer.probe.touch_mode import TouchMode, TouchModeConfiguration
 from cartographer.task_executor import MultiprocessingExecutor
+from cartographer.telemetry import TelemetryReporter
+from cartographer.telemetry.backend import get_telemetry_backend
 from cartographer.toolhead import BacklashCompensatingToolhead
 
 if TYPE_CHECKING:
@@ -62,10 +67,12 @@ class MacroRegistration:
 @final
 class PrinterCartographer:
     def __init__(self, adapters: Adapters) -> None:
+        self._adapters = adapters
         self.mcu = adapters.mcu
         self.config = adapters.config
         self.scheduler = adapters.scheduler
         self.task_executor = MultiprocessingExecutor(self.scheduler)
+        self.events = EventBus()
 
         # Initialize toolhead with optional backlash compensation
         toolhead = self._create_toolhead(adapters.toolhead)
@@ -86,6 +93,38 @@ class PrinterCartographer:
 
     def ready_callback(self) -> None:
         self.validate_and_load_models()
+        self._setup_telemetry()
+
+    def _setup_telemetry(self) -> None:
+        if not self.config.general.telemetry:
+            return
+        backend = get_telemetry_backend()
+        if backend is None:
+            return
+        reporter = TelemetryReporter(backend, self._adapters)
+        self.events.subscribe(
+            ScanCalibrationEvent,
+            lambda e: reporter.send_event(
+                "scan_calibration",
+                method=e.method,
+            ),
+        )
+        self.events.subscribe(
+            TouchCalibrationEvent,
+            lambda e: reporter.send_event(
+                "touch_calibration",
+                threshold=e.threshold,
+                speed=e.speed,
+                median_range=e.median_range,
+            ),
+        )
+        self.events.subscribe(
+            TemperatureCalibrationEvent,
+            lambda e: reporter.send_event(
+                "temperature_calibration",
+            ),
+        )
+        reporter.send_startup_event()
 
     def validate_and_load_models(self) -> None:
         mcu_version = self.mcu.get_mcu_version()
@@ -228,6 +267,7 @@ class PrinterCartographer:
                             adapters.gcode,
                             self.task_executor,
                             self.scheduler,
+                            self.events,
                         ),
                     ),
                 ]
@@ -241,7 +281,7 @@ class PrinterCartographer:
                 [
                     self._register_macro(
                         "SCAN_CALIBRATE",
-                        ScanCalibrateMacro(probe, toolhead, self.config),
+                        ScanCalibrateMacro(probe, toolhead, self.config, self.events),
                     ),
                     self._register_macro(
                         "SCAN_ACCURACY",
@@ -266,7 +306,14 @@ class PrinterCartographer:
                 [
                     self._register_macro(
                         "TOUCH_CALIBRATE",
-                        TouchCalibrateMacro(probe, self.mcu, toolhead, self.config, self.task_executor),
+                        TouchCalibrateMacro(
+                            probe,
+                            self.mcu,
+                            toolhead,
+                            self.config,
+                            self.task_executor,
+                            self.events,
+                        ),
                     ),
                     self._register_macro(
                         "TOUCH_MODEL",

--- a/src/cartographer/events.py
+++ b/src/cartographer/events.py
@@ -1,0 +1,43 @@
+from __future__ import annotations
+
+import logging
+from dataclasses import dataclass
+from typing import Any, Callable, TypeVar
+
+
+@dataclass(frozen=True)
+class Event:
+    """Base class for all events.
+
+    Events must be frozen dataclasses.
+    """
+
+
+T = TypeVar("T", bound=Event)
+
+logger = logging.getLogger(__name__)
+
+
+class EventBus:
+    def __init__(self) -> None:
+        self._subscriptions: dict[type, list[Callable[[Any], None]]] = {}  # pyright: ignore[reportExplicitAny]
+
+    def subscribe(self, event_type: type[T], callback: Callable[[T], None]) -> None:
+        """Subscribe to events of a specific type."""
+        self._subscriptions.setdefault(event_type, []).append(callback)
+
+    def unsubscribe(self, event_type: type[T], callback: Callable[[T], None]) -> None:
+        """Unsubscribe from events of a specific type."""
+        if event_type in self._subscriptions:
+            self._subscriptions[event_type].remove(callback)
+
+    def publish(self, event: object) -> None:
+        """Publish an event to all subscribers of its type."""
+        event_type = type(event)
+        logger.debug("Publishing event %s", event)
+
+        for callback in self._subscriptions.get(event_type, []) + self._subscriptions.get(Event, []):
+            try:
+                callback(event)
+            except (OSError, TypeError, KeyError, AttributeError, ValueError) as e:
+                logger.error("Error in event callback: %s", e)

--- a/src/cartographer/interfaces/configuration.py
+++ b/src/cartographer/interfaces/configuration.py
@@ -148,6 +148,7 @@ class GeneralConfig:
         " E.g. 'CARTO' would result in 'CARTO_TOUCH_HOME'.",
         default=None,
     )
+    telemetry: bool = option("Set to yes to enable anonymous usage telemetry.", default=False)
 
 
 @dataclass(frozen=True)

--- a/src/cartographer/macros/scan_calibrate.py
+++ b/src/cartographer/macros/scan_calibrate.py
@@ -8,18 +8,25 @@ from typing import TYPE_CHECKING, final
 
 from typing_extensions import assert_never, override
 
+from cartographer.events import Event
 from cartographer.interfaces.printer import Macro, MacroParams, Position, Toolhead
 from cartographer.macros.fields import param, parse
 from cartographer.probe import Probe, ScanModel
 
 if TYPE_CHECKING:
+    from cartographer.events import EventBus
     from cartographer.interfaces.configuration import Configuration
-
-    pass
 
 logger = logging.getLogger(__name__)
 
 DEFAULT_SCAN_MODEL_NAME = "default"
+
+
+@dataclass(frozen=True)
+class ScanCalibrationEvent(Event):
+    """Emitted after a successful scan calibration."""
+
+    method: str  # "touch" or "manual"
 
 
 class ScanCalibrateMethod(Enum):
@@ -44,10 +51,12 @@ class ScanCalibrateMacro(Macro):
         probe: Probe,
         toolhead: Toolhead,
         config: Configuration,
+        events: EventBus,
     ) -> None:
         self._probe = probe
         self._toolhead = toolhead
         self._config = config
+        self._events = events
 
     @override
     def run(self, params: MacroParams) -> None:
@@ -66,27 +75,27 @@ class ScanCalibrateMacro(Macro):
         self._toolhead.wait_moves()
 
         if p.method == ScanCalibrateMethod.TOUCH:
-            return self._run_touch(name)
+            return self._run_touch(name, p.method.value)
         elif p.method == ScanCalibrateMethod.MANUAL:
-            return self._run_manual(name)
+            return self._run_manual(name, p.method.value)
 
         assert_never(p.method)
 
-    def _run_touch(self, name: str) -> None:
+    def _run_touch(self, name: str, method: str) -> None:
         trigger_pos = self._probe.perform_touch()
         pos = self._toolhead.get_position()
         self._toolhead.set_z_position(pos.z - trigger_pos)
-        self._calibrate(name)
+        self._calibrate(name, method)
 
-    def _run_manual(self, name: str) -> None:
+    def _run_manual(self, name: str, method: str) -> None:
         _, z_max = self._toolhead.get_axis_limits("z")
         self._toolhead.set_z_position(z=z_max - 10)
 
         logger.info("Triggering manual probe, please bring nozzle to 0.1mm above the bed")
 
-        self._toolhead.manual_probe(partial(self._handle_manual_probe, name))
+        self._toolhead.manual_probe(partial(self._handle_manual_probe, name, method))
 
-    def _handle_manual_probe(self, name: str, pos: Position | None) -> None:
+    def _handle_manual_probe(self, name: str, method: str, pos: Position | None) -> None:
         if pos is None:
             self._toolhead.clear_z_homing_state()
             return
@@ -95,9 +104,9 @@ class ScanCalibrateMacro(Macro):
         # We assume the user will move the nozzle to 0.1mm above the bed
         self._toolhead.set_z_position(0.1)
 
-        self._calibrate(name)
+        self._calibrate(name, method)
 
-    def _calibrate(self, name: str):
+    def _calibrate(self, name: str, method: str):
         self._toolhead.move(z=5.5, speed=self._config.general.lift_speed)
         self._toolhead.wait_moves()
 
@@ -126,3 +135,4 @@ class ScanCalibrateMacro(Macro):
             "The SAVE_CONFIG command will update the printer config file and restart the printer.",
             name,
         )
+        self._events.publish(ScanCalibrationEvent(method=method))

--- a/src/cartographer/macros/temperature_calibrate.py
+++ b/src/cartographer/macros/temperature_calibrate.py
@@ -8,6 +8,7 @@ from typing import TYPE_CHECKING, final
 from typing_extensions import override
 
 from cartographer.coil.calibration import fit_coil_temperature_model
+from cartographer.events import Event
 from cartographer.interfaces.printer import GCodeDispatch, Macro, MacroParams, Mcu, Sample, Toolhead
 from cartographer.lib import scipy_helpers
 from cartographer.lib.csv import generate_filepath, write_samples_to_csv
@@ -15,10 +16,17 @@ from cartographer.lib.log import log_duration
 from cartographer.macros.fields import param, parse
 
 if TYPE_CHECKING:
+    from cartographer.events import EventBus
     from cartographer.interfaces.configuration import Configuration
     from cartographer.interfaces.multiprocessing import Scheduler, TaskExecutor
 
 logger = logging.getLogger(__name__)
+
+
+@dataclass(frozen=True)
+class TemperatureCalibrationEvent(Event):
+    """Emitted after a successful temperature calibration."""
+
 
 # Temperature monitoring constants
 TEMP_CHECK_INTERVAL = 1.0  # Check temperature every second
@@ -54,6 +62,7 @@ class TemperatureCalibrateMacro(Macro):
         gcode: GCodeDispatch,
         task_executor: TaskExecutor,
         scheduler: Scheduler,
+        events: EventBus,
     ) -> None:
         self.mcu = mcu
         self.toolhead = toolhead
@@ -61,6 +70,7 @@ class TemperatureCalibrateMacro(Macro):
         self.gcode = gcode
         self.task_executor = task_executor
         self.scheduler = scheduler
+        self._events = events
 
     @override
     def run(self, params: MacroParams) -> None:
@@ -121,6 +131,8 @@ class TemperatureCalibrateMacro(Macro):
         model = self.task_executor.run(fit_coil_temperature_model, data_per_height, self.mcu.get_coil_reference())
 
         self.config.save_coil_model(model)
+
+        self._events.publish(TemperatureCalibrationEvent())
 
         logger.info(
             "Temperature calibration complete!\n"

--- a/src/cartographer/macros/touch/__init__.py
+++ b/src/cartographer/macros/touch/__init__.py
@@ -5,5 +5,8 @@ from cartographer.macros.touch.calibrate import (
 from cartographer.macros.touch.calibrate import (
     TouchCalibrateMacro as TouchCalibrateMacro,
 )
+from cartographer.macros.touch.calibrate import (
+    TouchCalibrationEvent as TouchCalibrationEvent,
+)
 from cartographer.macros.touch.home import TouchHomeMacro as TouchHomeMacro
 from cartographer.macros.touch.probe import TouchProbeMacro as TouchProbeMacro

--- a/src/cartographer/macros/touch/calibrate.py
+++ b/src/cartographer/macros/touch/calibrate.py
@@ -8,6 +8,7 @@ from typing import TYPE_CHECKING, final
 import numpy as np
 from typing_extensions import Protocol, override, runtime_checkable
 
+from cartographer.events import Event
 from cartographer.interfaces.configuration import (
     Configuration,
     TouchModelConfiguration,
@@ -28,6 +29,7 @@ from cartographer.probe.touch_mode import (
 if TYPE_CHECKING:
     from collections.abc import Sequence
 
+    from cartographer.events import EventBus
     from cartographer.interfaces.multiprocessing import TaskExecutor
     from cartographer.interfaces.printer import Toolhead
     from cartographer.probe.probe import Probe
@@ -40,6 +42,15 @@ MIN_STEP = 50
 MAX_STEP = 1000
 DEFAULT_TOUCH_MODEL_NAME = "default"
 DEFAULT_Z_OFFSET = -0.05
+
+
+@dataclass(frozen=True)
+class TouchCalibrationEvent(Event):
+    """Emitted after a successful touch calibration."""
+
+    threshold: int
+    speed: int
+    median_range: float
 
 
 @dataclass(frozen=True)
@@ -246,12 +257,14 @@ class TouchCalibrateMacro(Macro):
         toolhead: Toolhead,
         config: Configuration,
         task_executor: TaskExecutor,
+        events: EventBus,
     ) -> None:
         self._probe = probe
         self._mcu = mcu
         self._toolhead = toolhead
         self._config = config
         self._task_executor = task_executor
+        self._events = events
 
     @override
     def run(self, params: MacroParams) -> None:
@@ -307,7 +320,7 @@ class TouchCalibrateMacro(Macro):
         verifier = ThresholdVerifier(calibration_mode)
 
         with force_home_z(self._toolhead):
-            threshold = self._find_threshold(
+            result = self._find_threshold(
                 screener,
                 verifier,
                 p.threshold_start,
@@ -317,11 +330,11 @@ class TouchCalibrateMacro(Macro):
                 p.verification_samples,
             )
 
-        if threshold is None:
+        if result is None:
             self._log_calibration_failure(p.threshold_start, p.threshold_max)
             return
 
-        self._save_calibration_result(name, threshold, p.speed)
+        self._save_calibration_result(name, result.threshold, p.speed, result.median_range)
 
     def _move_to_calibration_position(self) -> None:
         """Move to the zero reference position for calibration."""
@@ -341,7 +354,7 @@ class TouchCalibrateMacro(Macro):
         sample_range: float,
         max_verify_range: float,
         verification_samples: int,
-    ) -> int | None:
+    ) -> VerificationResult | None:
         """
         Find the minimum threshold that produces consistent results.
 
@@ -349,6 +362,8 @@ class TouchCalibrateMacro(Macro):
         1. Screen with few samples - pass if any valid subset found
         2. If screening passes, verify with multiple actual touch probes
         3. Accept if probe results are consistent
+
+        Returns the passing VerificationResult, or None if no threshold worked.
         """
         threshold = threshold_start
         screening_samples = self._config.touch.samples + self._config.touch.max_noisy_samples
@@ -383,7 +398,7 @@ class TouchCalibrateMacro(Macro):
                     format_distance(verification.median_range),
                     len(verification.probe_medians),
                 )
-                return threshold
+                return verification
 
             # Consistency check failed - increase threshold
             logger.debug(
@@ -416,6 +431,7 @@ class TouchCalibrateMacro(Macro):
         name: str,
         threshold: int,
         speed: int,
+        median_range: float,
     ) -> None:
         """Save the calibration result and log success."""
         logger.info(
@@ -432,6 +448,7 @@ class TouchCalibrateMacro(Macro):
             "file and restart the printer.",
             name,
         )
+        self._events.publish(TouchCalibrationEvent(threshold=threshold, speed=speed, median_range=median_range))
 
     def _log_screening_result(
         self,

--- a/src/cartographer/runtime/adapters.py
+++ b/src/cartographer/runtime/adapters.py
@@ -11,6 +11,7 @@ if TYPE_CHECKING:
 
 
 class Adapters(Protocol):
+    environment: str
     config: Configuration
     toolhead: Toolhead
     mcu: Mcu

--- a/src/cartographer/telemetry/__init__.py
+++ b/src/cartographer/telemetry/__init__.py
@@ -1,0 +1,57 @@
+from __future__ import annotations
+
+import logging
+from datetime import datetime, timezone
+from functools import cached_property
+from typing import TYPE_CHECKING, final
+
+from cartographer.telemetry.collector import collect_startup_data
+from cartographer.telemetry.identity import get_or_create_anonymous_id
+
+if TYPE_CHECKING:
+    from cartographer.runtime.adapters import Adapters
+    from cartographer.telemetry.backend import TelemetryBackend
+
+logger = logging.getLogger(__name__)
+
+
+@final
+class TelemetryReporter:
+    """Collects and forwards anonymous usage telemetry.
+
+    All exceptions are caught internally so telemetry can never crash Klipper.
+    """
+
+    def __init__(self, backend: TelemetryBackend, adapters: Adapters) -> None:
+        self._backend = backend
+        self._adapters = adapters
+
+    @cached_property
+    def anonymous_id(self) -> str:
+        """Persistent anonymous installation UUID."""
+        return get_or_create_anonymous_id()
+
+    def send_startup_event(self) -> None:
+        """Collect and send startup telemetry."""
+        try:
+            payload = collect_startup_data(self._adapters, self.anonymous_id)
+            self._backend.send(payload)
+        except (OSError, TypeError, KeyError, AttributeError, ValueError) as exc:
+            logger.warning("Telemetry: unexpected error in send_startup_event: %s", exc)
+
+    def send_event(self, event: str, **fields: object) -> None:
+        """Send a named event with arbitrary fields."""
+        try:
+            from cartographer import __version__
+
+            payload: dict[str, object] = {
+                "timestamp": datetime.now(tz=timezone.utc).isoformat(),
+                "event": event,
+                "anonymous_id": self.anonymous_id,
+                "plugin_version": __version__,
+                "mcu_version": self._adapters.mcu.get_mcu_version(),
+                **fields,
+            }
+            self._backend.send(payload)
+        except (OSError, TypeError, KeyError, AttributeError, ValueError) as exc:
+            logger.warning("Telemetry: unexpected error in send_event(%s): %s", event, exc)

--- a/src/cartographer/telemetry/backend.py
+++ b/src/cartographer/telemetry/backend.py
@@ -1,0 +1,77 @@
+from __future__ import annotations
+
+import json
+import logging
+import threading
+import urllib.request
+from typing import runtime_checkable
+
+from typing_extensions import Protocol, final
+
+
+def _read_token() -> str:
+    try:
+        from cartographer.telemetry._token import TOKEN
+    except ImportError:
+        return ""
+    return TOKEN  # type: ignore[no-any-return]
+
+
+logger = logging.getLogger(__name__)
+
+
+def get_telemetry_backend() -> TelemetryBackend | None:
+    """Return a backend if a telemetry token is available, else ``None``."""
+    token = _read_token()
+    if token:
+        return BetterStackBackend(token)
+    return None
+
+
+@runtime_checkable
+class TelemetryBackend(Protocol):
+    """Protocol for telemetry backends.
+
+    Implementations must send the payload without blocking the caller
+    and must never raise exceptions that could crash Klipper.
+    """
+
+    def send(self, payload: dict[str, object]) -> None: ...
+
+
+@final
+class BetterStackBackend:
+    """Sends telemetry events to BetterStack Logs via HTTP POST."""
+
+    _DEFAULT_ENDPOINT: str = "https://in.logs.betterstack.com"
+    _TIMEOUT: int = 10
+
+    def __init__(
+        self,
+        source_token: str,
+        endpoint: str = _DEFAULT_ENDPOINT,
+    ) -> None:
+        self._source_token = source_token
+        self._endpoint = endpoint
+
+    def send(self, payload: dict[str, object]) -> None:
+        """Fire-and-forget: send payload in a daemon thread. Never raises."""
+        thread = threading.Thread(target=self._post, args=(payload,), daemon=True)
+        thread.start()
+
+    def _post(self, payload: dict[str, object]) -> None:
+        try:
+            data = json.dumps(payload).encode("utf-8")
+            req = urllib.request.Request(
+                self._endpoint,
+                data=data,
+                headers={
+                    "Authorization": f"Bearer {self._source_token}",
+                    "Content-Type": "application/json",
+                },
+                method="POST",
+            )
+            with urllib.request.urlopen(req, timeout=self._TIMEOUT) as resp:
+                logger.debug("Telemetry: event sent (status=%s).", resp.status)
+        except (OSError, ValueError, TypeError) as exc:
+            logger.warning("Telemetry: failed to send event: %s", exc)

--- a/src/cartographer/telemetry/collector.py
+++ b/src/cartographer/telemetry/collector.py
@@ -1,0 +1,93 @@
+from __future__ import annotations
+
+import dataclasses
+import logging
+import platform
+from collections.abc import Sequence
+from datetime import datetime, timezone
+from enum import Enum
+from typing import TYPE_CHECKING
+
+from cartographer import __version__
+
+if TYPE_CHECKING:
+    from _typeshed import DataclassInstance
+
+    from cartographer.runtime.adapters import Adapters
+
+logger = logging.getLogger(__name__)
+
+# Fields excluded from per-section serialisation.
+_GENERAL_SKIP: set[str] = {"mcu"}
+_SCAN_SKIP: set[str] = {"models"}
+_TOUCH_SKIP: set[str] = {"models"}
+# faulty_regions is a nested tuple structure and not useful for high-level analytics.
+_BED_MESH_SKIP: set[str] = {"faulty_regions"}
+
+
+def _to_json_value(val: object) -> object:
+    """Recursively convert *val* to a JSON-serialisable type.
+
+    * ``Enum`` → ``.value``
+    * ``Sequence`` (tuple, list) → ``list`` (recursive)
+    * Everything else is returned as-is (caller's responsibility to ensure
+      JSON-compatibility for complex types).
+    """
+    if isinstance(val, Enum):
+        return _to_json_value(val.value)
+    if isinstance(val, Sequence) and not isinstance(val, (str, bytes)):
+        return [_to_json_value(item) for item in val]
+    return val
+
+
+def _dataclass_to_dict(obj: DataclassInstance, skip: set[str] | None = None) -> dict[str, object]:
+    """Serialise a dataclass instance to a JSON-compatible dict.
+
+    Fields listed in *skip* are omitted.  ``ClassVar`` fields are
+    automatically excluded by ``dataclasses.fields()``.
+    """
+    result: dict[str, object] = {}
+    for f in dataclasses.fields(obj):
+        if skip and f.name in skip:
+            continue
+        result[f.name] = _to_json_value(getattr(obj, f.name))
+    return result
+
+
+def _utc_now() -> str:
+    return datetime.now(tz=timezone.utc).isoformat()
+
+
+def collect_startup_data(adapters: Adapters, anonymous_id: str) -> dict[str, object]:
+    """Build the startup telemetry payload."""
+    cfg = adapters.config
+
+    return {
+        "timestamp": _utc_now(),
+        "event": "startup",
+        "anonymous_id": anonymous_id,
+        "plugin_version": __version__,
+        "environment": adapters.environment,
+        "python_version": platform.python_version(),
+        "os_platform": platform.platform(),
+        "os_arch": platform.machine(),
+        "mcu_version": adapters.mcu.get_mcu_version(),
+        "config": {
+            "general": _dataclass_to_dict(cfg.general, skip=_GENERAL_SKIP),
+            "scan": _dataclass_to_dict(cfg.scan, skip=_SCAN_SKIP),
+            "touch": _dataclass_to_dict(cfg.touch, skip=_TOUCH_SKIP),
+            "bed_mesh": _dataclass_to_dict(cfg.bed_mesh, skip=_BED_MESH_SKIP),
+            "coil": {"has_calibration": cfg.coil.calibration is not None},
+        },
+        # TODO: expose kinematics type via the Toolhead protocol.
+        "kinematics": "unknown",
+        "bed_size": {
+            "min": list(cfg.bed_mesh.mesh_min),
+            "max": list(cfg.bed_mesh.mesh_max),
+        },
+        "calibration_summary": {
+            "scan_models_count": len(cfg.scan.models),
+            "touch_models_count": len(cfg.touch.models),
+            "has_temperature_calibration": cfg.coil.calibration is not None,
+        },
+    }

--- a/src/cartographer/telemetry/identity.py
+++ b/src/cartographer/telemetry/identity.py
@@ -1,0 +1,38 @@
+from __future__ import annotations
+
+import logging
+import uuid
+from pathlib import Path
+
+logger = logging.getLogger(__name__)
+
+_ID_FILE = Path.home() / ".cartographer3d" / "telemetry_id"
+
+
+def get_or_create_anonymous_id() -> str:
+    """Return a persistent anonymous UUID for this installation.
+
+    The UUID is stored in ``~/.cartographer3d/telemetry_id``.  If the file
+    cannot be read or written (e.g. permission error) a transient UUID is
+    returned and a warning is logged.
+    """
+    try:
+        _ID_FILE.parent.mkdir(parents=True, exist_ok=True)
+        if _ID_FILE.exists():
+            content = _ID_FILE.read_text().strip()
+            if content:
+                return content
+        new_id = str(uuid.uuid4())
+        _ = _ID_FILE.write_text(new_id)
+        return new_id
+    except PermissionError as exc:
+        logger.warning(
+            "Telemetry: could not read/write anonymous ID (%s); using transient ID.",
+            exc,
+        )
+    except (OSError, ValueError) as exc:
+        logger.warning(
+            "Telemetry: unexpected error reading anonymous ID (%s); using transient ID.",
+            exc,
+        )
+    return str(uuid.uuid4())


### PR DESCRIPTION
## Summary

Adds anonymous usage telemetry behind a config flag (`telemetry: True`, default off). Sends structured events to BetterStack Logs to understand deployment landscape, config trends, and calibration usage. See `TELEMETRY.md` for full details on what is collected.

## Decisions & callouts

- Events sent via daemon threads (fire-and-forget) — never blocks Klipper
- No new pip dependencies — stdlib `urllib` only
- NullBackend when: telemetry disabled, no token baked in, or local dev build
- Startup event sent every boot; deduplicate at query time (BetterStack is append-only)
- Anonymous ID stored in `~/.cartographer3d/telemetry_id`

## Manual testing

- [ ] Add `telemetry: True` to `[cartographer]` — verify Klipper starts normally
- [ ] Run `CARTOGRAPHER_SCAN_CALIBRATE` — verify no errors, calibration completes
- [ ] Run `CARTOGRAPHER_TOUCH_CALIBRATE` — verify no errors, calibration completes
- [ ] Remove `telemetry` option — verify Klipper starts without warnings
- [ ] Verify no network calls when telemetry is disabled (check debug logs)