### PR TITLE
fix(coil): relax BED_TEMP validation for temperature calibration

### DIFF
--- a/src/cartographer/macros/temperature_calibrate.py
+++ b/src/cartographer/macros/temperature_calibrate.py
@@ -71,8 +71,8 @@ class TemperatureCalibrateMacro(Macro):
         if p.max_temp < p.min_temp + 20:
             msg = f"MAX_TEMP ({p.max_temp}) must be at least MIN_TEMP + 20 ({p.min_temp + 20})"
             raise RuntimeError(msg)
-        if p.bed_temp < p.max_temp + 30:
-            msg = f"BED_TEMP ({p.bed_temp}) must be at least MAX_TEMP + 30 ({p.max_temp + 30})"
+        if p.bed_temp < p.max_temp:
+            msg = f"BED_TEMP ({p.bed_temp}) must be at least MAX_TEMP ({p.max_temp})"
             raise RuntimeError(msg)
 
         if not self.toolhead.is_homed("x") or not self.toolhead.is_homed("y") or not self.toolhead.is_homed("z"):


### PR DESCRIPTION
## Summary

Relaxes the `BED_TEMP` validation in `CARTOGRAPHER_CALIBRATE_TEMPERATURE` from
`BED_TEMP ≥ MAX_TEMP + 30` to `BED_TEMP ≥ MAX_TEMP`.

Some printers (e.g. enclosed machines with chamber heaters) can drive the coil
to high temperatures without relying on extreme bed temperatures. The +30°C
margin was overly conservative and prevented valid calibration scenarios.

## Decisions & callouts

- The check is now `bed_temp < max_temp` (i.e. `≥`, not `>`), so `BED_TEMP == MAX_TEMP` is valid.
  This is intentional — on some setups the bed isn't the primary heat source for the coil.
- The `bed_temp` param bounds (`min=90, max=120`) are unchanged.