### PR TITLE
fix(mcu): correct comms-timeout check for Klipper v0.12 reason ordering

### DIFF
--- a/src/cartographer/adapters/klipper_v12/trigger_dispatch.py
+++ b/src/cartographer/adapters/klipper_v12/trigger_dispatch.py
@@ -98,7 +98,8 @@ class TriggerDispatch:
         _ffi_main, ffi_lib = chelper.get_ffi()
         ffi_lib.trdispatch_stop(self._trdispatch)
         res = [trsync.stop() for trsync in self._trsyncs]
-        err_res = [r for r in res if r >= MCU_trsync.REASON_COMMS_TIMEOUT]
+        # `==` not `>=`: v0.12 orders COMMS_TIMEOUT=2 below HOST_REQUEST=3 and PAST_END_TIME=4.
+        err_res = [r for r in res if r == MCU_trsync.REASON_COMMS_TIMEOUT]
         if err_res:
             return err_res[0]
         return res[0]

--- a/src/cartographer/mcu/mcu.py
+++ b/src/cartographer/mcu/mcu.py
@@ -168,7 +168,7 @@ class CartographerMcu(Mcu, CartographerStreamMcu):
         self.dispatch.wait_end(home_end_time)
         self.commands.send_stop_home()
         result = self.dispatch.stop()
-        if result >= MCU_trsync.REASON_COMMS_TIMEOUT:
+        if result == MCU_trsync.REASON_COMMS_TIMEOUT:
             msg = "Communication timeout during homing"
             raise RuntimeError(msg)
         if result != MCU_trsync.REASON_ENDSTOP_HIT:


### PR DESCRIPTION
## Summary

Fixes a spurious `Communication timeout during homing` raised on every G28 on Qidi Plus4 (Klipper v0.12), reproduced on top of #494.

Qidi's Klipper v0.12 fork orders `MCU_trsync.REASON_*` differently from modern Klipper:

| reason            | v0.12 | modern |
|-------------------|------:|-------:|
| `ENDSTOP_HIT`     | 1     | 1      |
| `COMMS_TIMEOUT`   | **2** | 4      |
| `HOST_REQUEST`    | 3     | 2      |
| `PAST_END_TIME`   | 4     | 3      |

The `r >= REASON_COMMS_TIMEOUT` idiom in `stop_homing` and the bundled `TriggerDispatch.stop()` is a comms-timeout test that only works because modern Klipper made `COMMS_TIMEOUT` the largest value. On v0.12 it sits *below* `HOST_REQUEST` and `PAST_END_TIME`, so the filter spuriously matches the normal end-of-stroke reason and raises "Communication timeout during homing" whenever the scan stroke completes without crossing threshold.

Switch both call sites to `==`. Order-independent; behaviour on modern Klipper is unchanged (`COMMS_TIMEOUT` is the only value `>= COMMS_TIMEOUT` there anyway).

Reference: [`MCU_trsync` in QIDITECH/klipper PLUS4 branch](https://github.com/QIDITECH/klipper/blob/PLUS4/klippy/mcu.py#L105-L224).

## Repro on Plus4

```
SET_KINEMATIC_POSITION pos=8.500,8.000,275.000
[cartographer] Sending trigger frequency threshold command [37542385, 37317130]
[cartographer] Sending home command [0, 1, 0, 0, <TriggerMethod.SCAN: 0>]
...
[cartographer] Sending stop home command
Communication timeout during homing
```

Calibration passes, G28 fails with the above.

## Test plan

- [ ] G28 completes on Qidi Plus4 (Klipper v0.12) without the spurious timeout
- [ ] No regression on modern Klipper — `stop_homing` still raises on a real `COMMS_TIMEOUT` and still returns `0.0` on `PAST_END_TIME` / `HOST_REQUEST`