### PR TITLE
fix: expose get_lift_speed for Klipper v0.12 compat

### DIFF
--- a/src/cartographer/adapters/klipper/probe.py
+++ b/src/cartographer/adapters/klipper/probe.py
@@ -72,7 +72,8 @@ class KlipperCartographerProbe:
         self.toolhead = toolhead
         self.lift_speed = config.lift_speed
 
-    def _get_lift_speed(self, gcmd: GCodeCommand | None = None):
+    def get_lift_speed(self, gcmd: GCodeCommand | None = None):
+        """Part of PrinterProbe interface in Klipper <= v0.12. Called by extras like axis_twist_compensation."""
         if gcmd is None:
             return self.lift_speed
         return gcmd.get_float("LIFT_SPEED", self.lift_speed, above=0.0)
@@ -80,7 +81,7 @@ class KlipperCartographerProbe:
     def get_probe_params(self, gcmd: GCodeCommand | None = None):
         return {
             "probe_speed": 5,
-            "lift_speed": self._get_lift_speed(gcmd),
+            "lift_speed": self.get_lift_speed(gcmd),
             "samples": 1,
             "sample_retract_dist": 0.2,
             "samples_tolerance": 0.1,


### PR DESCRIPTION
## Summary

Klipper ≤ v0.12 extras (e.g. `axis_twist_compensation`) call `probe.get_lift_speed()` directly on whatever object is registered as the `"probe"`. Our `KlipperCartographerProbe` had the method as `_get_lift_speed` (private), causing an `AttributeError` at connect time on v0.12 firmware.

Renamed to public. The method is unused on latest Klipper (where lift speed moved to `ProbeParameterHelper`) but harmless.

## Decisions & callouts

- Kept a single `KlipperCartographerProbe` class shared by both the mainline and v0.12 adapters rather than creating a v12-specific subclass — the method is a 3-line accessor that's inert when uncalled.