### PR TITLE
fix: detect KlipperV12 via probe interface, not TriggerDispatch

### DIFF
--- a/src/cartographer/runtime/environment.py
+++ b/src/cartographer/runtime/environment.py
@@ -21,9 +21,10 @@ def detect_environment(config: object) -> Environment:
         pass
 
     try:
-        from mcu import TriggerDispatch
+        from extras.probe import PrinterProbe
 
-        del TriggerDispatch
+        if not hasattr(PrinterProbe, "start_probe_session"):
+            return Environment.KlipperV12
     except ImportError:
         return Environment.KlipperV12
 

--- a/tests/test_environment.py
+++ b/tests/test_environment.py
@@ -19,29 +19,30 @@ class TestDetectEnvironment:
 
         assert detect_environment(None) == Environment.Kalico
 
-    def test_detects_klipper_v12_when_trigger_dispatch_missing(self, mocker: MockerFixture) -> None:
-        """When mcu module exists but lacks TriggerDispatch, detect KlipperV12."""
+    def test_detects_klipper_v12_when_start_probe_session_missing(self, mocker: MockerFixture) -> None:
+        """When PrinterProbe lacks start_probe_session, detect KlipperV12."""
         # Stub klippy without APP_NAME (or not Kalico)
         klippy_mock = MagicMock(spec=[])
         mocker.patch.dict(sys.modules, {"klippy": klippy_mock})
 
-        # Stub mcu module without TriggerDispatch
-        mcu_mock = MagicMock(spec=["MCU", "MCU_trsync", "get_printer_mcu"])
-        mocker.patch.dict(sys.modules, {"mcu": mcu_mock})
+        # Stub extras.probe with PrinterProbe that lacks start_probe_session
+        probe_mock = MagicMock()
+        probe_mock.PrinterProbe = type("PrinterProbe", (), {})
+        mocker.patch.dict(sys.modules, {"extras": MagicMock(), "extras.probe": probe_mock})
 
         from cartographer.runtime.environment import Environment, detect_environment
 
         assert detect_environment(None) == Environment.KlipperV12
 
-    def test_detects_klipper_when_trigger_dispatch_present(self, mocker: MockerFixture) -> None:
-        """When mcu.TriggerDispatch exists, detect modern Klipper."""
+    def test_detects_klipper_when_start_probe_session_present(self, mocker: MockerFixture) -> None:
+        """When PrinterProbe has start_probe_session, detect modern Klipper."""
         klippy_mock = MagicMock(spec=[])
         mocker.patch.dict(sys.modules, {"klippy": klippy_mock})
 
-        # Stub mcu module WITH TriggerDispatch
-        mcu_mock = MagicMock()
-        mcu_mock.TriggerDispatch = MagicMock()
-        mocker.patch.dict(sys.modules, {"mcu": mcu_mock})
+        # Stub extras.probe with PrinterProbe that has start_probe_session
+        probe_mock = MagicMock()
+        probe_mock.PrinterProbe = type("PrinterProbe", (), {"start_probe_session": None})
+        mocker.patch.dict(sys.modules, {"extras": MagicMock(), "extras.probe": probe_mock})
 
         from cartographer.runtime.environment import Environment, detect_environment
 


### PR DESCRIPTION
## Summary

Klipper v0.12.0-208 has `TriggerDispatch` but still uses the old probe interface
(no `start_probe_session` on `PrinterProbe`). Our detection based on `TriggerDispatch`
presence misclassifies these builds as latest Klipper, causing `AttributeError` on
`get_lift_speed` at connect time.

Switch detection to check `hasattr(PrinterProbe, "start_probe_session")` — this is
the actual boundary for the probe interface change. Builds without it get the v12
adapter, which bundles `TriggerDispatch` redundantly but harmlessly for those that
already have it natively.

## Install command

```
~/klippy-env/bin/pip install --no-cache-dir --force-reinstall "git+https://github.com/Cartographer3D/cartographer3d-plugin.git@fix/v12-detection"
sudo systemctl restart klipper
```

To revert to the latest stable release:
```
~/klippy-env/bin/pip install --no-cache-dir --force-reinstall cartographer3d-plugin
sudo systemctl restart klipper
```

## Decisions & callouts

- **Redundant TriggerDispatch**: builds like v0.12.0-208 that have `TriggerDispatch`
  natively will now use our bundled port instead. This is harmless — our port is
  faithful and functionally identical. The alternative (a third environment variant)
  adds complexity for a narrow transitional window.

- **Detection signal**: `start_probe_session` on the `PrinterProbe` class is the true
  boundary between old and new probe APIs. Since Klipper evolves monotonically
  (TriggerDispatch always precedes session-based probes), this is a strictly later
  signal that implies all prior features exist.

## Manual testing

- [ ] On Klipper v0.12.0-208+: verify environment detects as `klipper_v12`
- [ ] Verify probing, homing, and axis twist compensation work
- [ ] On latest Klipper: verify still detects as `klipper` and works normally