### PR TITLE
fix: abort blocked operations on printer shutdown

### DIFF
--- a/src/cartographer/adapters/kalico/adapters.py
+++ b/src/cartographer/adapters/kalico/adapters.py
@@ -9,7 +9,7 @@ from cartographer.adapters.kalico.toolhead import KalicoToolhead
 from cartographer.adapters.klipper.bed_mesh import KlipperBedMesh
 from cartographer.adapters.klipper.configuration import KlipperConfiguration
 from cartographer.adapters.klipper.gcode import KlipperGCodeDispatch
-from cartographer.adapters.klipper.scheduler import KlipperScheduler
+from cartographer.adapters.klipper_like.scheduler import KlipperScheduler
 from cartographer.config.fields import parse
 from cartographer.interfaces.configuration import GeneralConfig
 from cartographer.mcu.mcu import CartographerMcu
@@ -26,7 +26,7 @@ logger = logging.getLogger(__name__)
 class KalicoAdapters(Adapters):
     def __init__(self, config: KlipperConfigWrapper) -> None:
         self.printer = config.get_printer()
-        self.scheduler = KlipperScheduler(self.printer.get_reactor())
+        self.scheduler = KlipperScheduler(self.printer.get_reactor(), self.printer.is_shutdown)
 
         general = parse(GeneralConfig, config)
         platform = KalicoMcuPlatform(config, general.mcu)

--- a/src/cartographer/adapters/klipper/adapters.py
+++ b/src/cartographer/adapters/klipper/adapters.py
@@ -8,8 +8,8 @@ from cartographer.adapters.klipper.bed_mesh import KlipperBedMesh
 from cartographer.adapters.klipper.configuration import KlipperConfiguration
 from cartographer.adapters.klipper.gcode import KlipperGCodeDispatch
 from cartographer.adapters.klipper.mcu_platform import KlipperMcuPlatform
-from cartographer.adapters.klipper.scheduler import KlipperScheduler
 from cartographer.adapters.klipper.toolhead import KlipperToolhead
+from cartographer.adapters.klipper_like.scheduler import KlipperScheduler
 from cartographer.config.fields import parse
 from cartographer.interfaces.configuration import GeneralConfig
 from cartographer.mcu.mcu import CartographerMcu
@@ -26,7 +26,7 @@ logger = logging.getLogger(__name__)
 class KlipperAdapters(Adapters):
     def __init__(self, config: KlipperConfigWrapper) -> None:
         self.printer = config.get_printer()
-        self.scheduler = KlipperScheduler(self.printer.get_reactor())
+        self.scheduler = KlipperScheduler(self.printer.get_reactor(), self.printer.is_shutdown)
 
         general = parse(GeneralConfig, config)
         platform = KlipperMcuPlatform(config, general.mcu)

--- a/src/cartographer/adapters/klipper_like/integrator.py
+++ b/src/cartographer/adapters/klipper_like/integrator.py
@@ -19,6 +19,7 @@ from cartographer.adapters.klipper.homing import KlipperHomingChip
 from cartographer.adapters.klipper.logging import setup_console_logger
 from cartographer.adapters.klipper.temperature import PrinterTemperatureCoil
 from cartographer.adapters.klipper_like.utils import reraise_for_klipper
+from cartographer.interfaces.errors import PrinterShutdownError
 from cartographer.interfaces.printer import Macro, MacroParams, SupportsFallbackMacro
 from cartographer.runtime.integrator import Integrator
 
@@ -97,7 +98,7 @@ class KlipperLikeIntegrator(Integrator, ABC):
             else:
                 logger.warning("No original macro found to fallback to for '%s'", name)
 
-        self._gcode.register_command(name, _catch_macro_errors(macro.run), desc=macro.description)
+        self._gcode.register_command(name, catch_macro_errors(macro.run), desc=macro.description)
 
     @override
     def register_coil_temperature_sensor(self) -> None:
@@ -127,11 +128,14 @@ class KlipperLikeIntegrator(Integrator, ABC):
         handler.setLevel(log_level)
 
 
-def _catch_macro_errors(func: Callable[[GCodeCommand], None]) -> Callable[[GCodeCommand], None]:
+def catch_macro_errors(func: Callable[[GCodeCommand], None]) -> Callable[[GCodeCommand], None]:
     @wraps(func)
     def wrapper(gcmd: GCodeCommand) -> None:
         try:
             func(gcmd)
+        except PrinterShutdownError:
+            msg = "Aborted: printer entered shutdown"
+            raise gcmd.error(msg) from None
         except (RuntimeError, ValueError) as e:
             msg = dedent(str(e)).replace("\n", " ").replace("  ", "\n").strip()
             raise gcmd.error(msg) from e

--- a/src/cartographer/adapters/klipper_like/scheduler.py
+++ b/src/cartographer/adapters/klipper_like/scheduler.py
@@ -4,6 +4,7 @@ from typing import TYPE_CHECKING, Callable, final, overload
 
 from typing_extensions import override
 
+from cartographer.interfaces.errors import PrinterShutdownError
 from cartographer.interfaces.multiprocessing import Scheduler
 
 if TYPE_CHECKING:
@@ -14,13 +15,16 @@ if TYPE_CHECKING:
 class KlipperScheduler(Scheduler):
     """Klipper-specific scheduler using the reactor pattern."""
 
-    def __init__(self, reactor: Reactor) -> None:
+    def __init__(self, reactor: Reactor, shutdown_check: Callable[[], bool]) -> None:
         self._reactor = reactor
+        self._shutdown_check = shutdown_check
 
     @override
     def sleep(self, seconds: float) -> None:
         eventtime = self._reactor.monotonic()
         _ = self._reactor.pause(eventtime + seconds)
+        if self._shutdown_check():
+            raise PrinterShutdownError()
 
     @overload
     def wait_until(
@@ -50,6 +54,8 @@ class KlipperScheduler(Scheduler):
 
         while not condition():
             eventtime = self._reactor.pause(eventtime + poll_interval)
+            if self._shutdown_check():
+                raise PrinterShutdownError()
             if eventtime >= end_time:
                 return False
 

--- a/src/cartographer/adapters/klipper_like/utils.py
+++ b/src/cartographer/adapters/klipper_like/utils.py
@@ -7,7 +7,7 @@ from gcode import CommandError
 from gcode import Coord as GCodeCoord
 from typing_extensions import ParamSpec
 
-from cartographer.interfaces.errors import ProbeTriggerError
+from cartographer.interfaces.errors import PrinterShutdownError, ProbeTriggerError
 
 if TYPE_CHECKING:
     from cartographer.interfaces.printer import Position
@@ -51,6 +51,9 @@ def reraise_for_klipper(
     def wrapper(*args: P.args, **kwargs: P.kwargs) -> R:
         try:
             return func(*args, **kwargs)
+        except PrinterShutdownError:
+            msg = "Aborted: printer entered shutdown"
+            raise CommandError(msg) from None
         except RuntimeError as e:
             raise CommandError(str(e)) from e
 

--- a/src/cartographer/adapters/klipper_v12/adapters.py
+++ b/src/cartographer/adapters/klipper_v12/adapters.py
@@ -6,8 +6,8 @@ from typing import TYPE_CHECKING, final
 from cartographer.adapters.klipper.bed_mesh import KlipperBedMesh
 from cartographer.adapters.klipper.configuration import KlipperConfiguration
 from cartographer.adapters.klipper.gcode import KlipperGCodeDispatch
-from cartographer.adapters.klipper.scheduler import KlipperScheduler
 from cartographer.adapters.klipper.toolhead import KlipperToolhead
+from cartographer.adapters.klipper_like.scheduler import KlipperScheduler
 from cartographer.adapters.klipper_v12.axis_twist_compensation import KlipperV12AxisTwistCompensationAdapter
 from cartographer.adapters.klipper_v12.mcu_platform import KlipperV12McuPlatform
 from cartographer.config.fields import parse
@@ -26,7 +26,7 @@ logger = logging.getLogger(__name__)
 class KlipperV12Adapters(Adapters):
     def __init__(self, config: KlipperConfigWrapper) -> None:
         self.printer = config.get_printer()
-        self.scheduler = KlipperScheduler(self.printer.get_reactor())
+        self.scheduler = KlipperScheduler(self.printer.get_reactor(), self.printer.is_shutdown)
 
         general = parse(GeneralConfig, config)
         platform = KlipperV12McuPlatform(config, general.mcu)

--- a/src/cartographer/interfaces/errors.py
+++ b/src/cartographer/interfaces/errors.py
@@ -3,3 +3,17 @@ from __future__ import annotations
 
 class ProbeTriggerError(RuntimeError):
     """Raised when probe triggers unexpectedly (e.g., before movement)."""
+
+
+class PrinterShutdownError(RuntimeError):
+    """Raised when an operation is interrupted because the printer entered shutdown."""
+
+    def __init__(self) -> None:
+        super().__init__("Printer entered shutdown")
+
+
+class McuDisconnectedError(RuntimeError):
+    """Raised when the MCU disconnects during an active operation."""
+
+    def __init__(self) -> None:
+        super().__init__("Cartographer MCU disconnected during session")

--- a/src/cartographer/interfaces/multiprocessing.py
+++ b/src/cartographer/interfaces/multiprocessing.py
@@ -41,7 +41,14 @@ class Scheduler(Protocol):
     """Abstract interface for time-based operations."""
 
     def sleep(self, seconds: float) -> None:
-        """Sleep for the specified duration."""
+        """
+        Sleep for the specified duration.
+
+        Raises
+        ------
+        PrinterShutdownError
+            If the printer enters shutdown while sleeping.
+        """
         ...
 
     @overload
@@ -84,5 +91,10 @@ class Scheduler(Protocol):
             If timeout is None, returns None (waits indefinitely).
             If timeout is specified, returns True if condition was met,
             False if timeout expired.
+
+        Raises
+        ------
+        PrinterShutdownError
+            If the printer enters shutdown while waiting.
         """
         ...

--- a/src/cartographer/mcu/mcu.py
+++ b/src/cartographer/mcu/mcu.py
@@ -7,6 +7,7 @@ from typing import TYPE_CHECKING, TypedDict, final
 from mcu import MCU_trsync
 from typing_extensions import override
 
+from cartographer.interfaces.errors import McuDisconnectedError, PrinterShutdownError
 from cartographer.interfaces.printer import CoilCalibrationReference, Mcu, Sample
 from cartographer.mcu.async_processor import AsyncProcessor
 from cartographer.mcu.commands import (
@@ -218,8 +219,11 @@ class CartographerMcu(Mcu, CartographerStreamMcu):
             self.stop_streaming()
 
     def _handle_shutdown(self) -> None:
-        if self._commands is not None and not self._platform.is_disconnected():
-            self.stop_streaming()
+        try:
+            if self._commands is not None and not self._platform.is_disconnected():
+                self.stop_streaming()
+        finally:
+            self._stream.abort_all_sessions(PrinterShutdownError())
 
     def register_reconnect_callback(self, callback: Callable[[], None]) -> None:
         self._reconnect_callbacks.append(callback)
@@ -237,7 +241,7 @@ class CartographerMcu(Mcu, CartographerStreamMcu):
     def _handle_disconnect(self) -> None:
         logger.warning("Cartographer MCU disconnected")
         self._sensor_ready = False
-        self._stream.abort_all_sessions()
+        self._stream.abort_all_sessions(McuDisconnectedError())
 
     def _handle_data(self, data: _RawData) -> None:
         """

--- a/src/cartographer/stream.py
+++ b/src/cartographer/stream.py
@@ -3,6 +3,8 @@ from __future__ import annotations
 from abc import ABC, abstractmethod
 from typing import Callable, Generic, Protocol, TypeVar
 
+from cartographer.interfaces.errors import McuDisconnectedError
+
 T = TypeVar("T")
 
 
@@ -16,8 +18,6 @@ class Condition(Protocol):
 
 
 class Session(Generic[T]):
-    _aborted: bool = False
-
     def __init__(
         self,
         stream: Stream[T],
@@ -28,8 +28,10 @@ class Session(Generic[T]):
         self.items: list[T] = []
         self.start_condition: Callable[[T], bool] | None = start_condition
         self._condition: Condition = condition
+        self._aborted: bool = False
+        self._abort_error: Exception | None = None
 
-    def add_item(self, item: T):
+    def add_item(self, item: T) -> None:
         """Adds an item to the session only after the start condition is met."""
         if self.start_condition is not None:
             if not self.start_condition(item):
@@ -39,26 +41,33 @@ class Session(Generic[T]):
         self.items.append(item)
         self._condition.notify_all()
 
-    def wait_for(self, condition: Callable[[list[T]], bool]):
+    def wait_for(self, condition: Callable[[list[T]], bool]) -> None:
         """Waits until the given condition function returns True.
 
-        Raises RuntimeError if the session was aborted (e.g. MCU disconnect).
+        Raises McuDisconnectedError (or the stored abort error) if the session was aborted.
         """
         self._condition.wait_for(lambda: self._aborted or condition(self.items))
         if self._aborted:
-            msg = "Cartographer MCU disconnected during session"
-            raise RuntimeError(msg)
+            if self._abort_error is not None:
+                raise self._abort_error
+            raise McuDisconnectedError()
 
     def get_items(self) -> list[T]:
         """Returns collected items after session ends."""
         return self.items
 
-    def abort(self) -> None:
-        """Abort this session; any waiter will wake and raise RuntimeError."""
+    def abort(self, error: Exception | None = None) -> None:
+        """Abort this session; any waiter will wake and raise the given error (or McuDisconnectedError).
+
+        Idempotent: the first abort reason wins; subsequent calls are no-ops.
+        """
+        if self._aborted:
+            return
+        self._abort_error = error
         self._aborted = True
         self._condition.notify_all()
 
-    def __enter__(self):
+    def __enter__(self) -> Session[T]:
         return self  # Allows using `with session:`
 
     def __exit__(
@@ -66,7 +75,7 @@ class Session(Generic[T]):
         exc_type: object,
         exc_val: object,
         exc_tb: object,
-    ):
+    ) -> None:
         """Automatically remove session from stream when exiting the with-block."""
         self.stream.end_session(self)
 
@@ -95,24 +104,24 @@ class Stream(ABC, Generic[T]):
         self.sessions.add(session)
         return session
 
-    def end_session(self, session: Session[T]):
+    def end_session(self, session: Session[T]) -> None:
         """Ends a session and removes it from active sessions."""
         self.sessions.discard(session)
 
-    def abort_all_sessions(self) -> None:
+    def abort_all_sessions(self, error: Exception | None = None) -> None:
         """Wake all waiting sessions so they detect abort and raise."""
         for session in list(self.sessions):
-            session.abort()
+            session.abort(error)
 
-    def register_callback(self, callback: Callable[[T], None]):
+    def register_callback(self, callback: Callable[[T], None]) -> None:
         """Registers a callback to the stream."""
         self.callbacks.add(callback)
 
-    def unregister_callback(self, callback: Callable[[T], None]):
+    def unregister_callback(self, callback: Callable[[T], None]) -> None:
         """Removes the callback from the stream."""
         self.callbacks.discard(callback)
 
-    def add_item(self, item: T):
+    def add_item(self, item: T) -> None:
         """Pushes the item to all active sessions."""
         self._last_item = item
 

--- a/src/cartographer/task_executor.py
+++ b/src/cartographer/task_executor.py
@@ -40,22 +40,27 @@ class MultiprocessingExecutor(TaskExecutor):
         proc = multiprocessing.Process(target=worker, args=(child_conn,), daemon=True)
         proc.start()
 
-        # Wait for data to be available
-        self._scheduler.wait_until(lambda: not proc.is_alive() or parent_conn.poll())
-
-        # Check if data is actually available
-        if not parent_conn.poll():
-            proc.join()
-            exit_code = proc.exitcode
-            parent_conn.close()
-            msg = f"Worker process terminated unexpectedly with exit code {exit_code}"
-            raise RuntimeError(msg)
-
-        # Receive result
         try:
-            is_error, payload = parent_conn.recv()
+            # Wait for data to be available
+            self._scheduler.wait_until(lambda: not proc.is_alive() or parent_conn.poll())
+
+            # Check if data is actually available
+            if not parent_conn.poll():
+                proc.join()
+                msg = f"Worker process terminated unexpectedly with exit code {proc.exitcode}"
+                raise RuntimeError(msg)
+
+            # Receive result
+            try:
+                is_error, payload = parent_conn.recv()
+            except EOFError:
+                proc.join()
+                msg = f"Worker process terminated unexpectedly with exit code {proc.exitcode}"
+                raise RuntimeError(msg) from None
         finally:
             parent_conn.close()
+            if proc.is_alive():
+                proc.terminate()
             proc.join()
 
         if is_error:

--- a/tests/klipper/test_error_propagation.py
+++ b/tests/klipper/test_error_propagation.py
@@ -1,0 +1,100 @@
+from __future__ import annotations
+
+from unittest.mock import Mock
+
+import pytest
+
+import cartographer.adapters.klipper_like.utils as _utils_module
+from cartographer.adapters.klipper_like.integrator import catch_macro_errors
+from cartographer.adapters.klipper_like.utils import reraise_for_klipper
+from cartographer.interfaces.errors import PrinterShutdownError
+
+
+class _FakeCommandError(Exception):
+    """Stand-in for gcode.CommandError used throughout this module."""
+
+
+class TestPrinterShutdownErrorPropagation:
+    # ------------------------------------------------------------------ #
+    # reraise_for_klipper                                                  #
+    # ------------------------------------------------------------------ #
+
+    def test_reraise_for_klipper_converts_printer_shutdown_to_command_error(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """PrinterShutdownError becomes CommandError with the shutdown message."""
+        monkeypatch.setattr(_utils_module, "CommandError", _FakeCommandError)
+
+        @reraise_for_klipper
+        def func() -> None:
+            raise PrinterShutdownError()
+
+        with pytest.raises(_FakeCommandError, match="Aborted: printer entered shutdown"):
+            func()
+
+    def test_reraise_for_klipper_converts_runtime_error_to_command_error(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        """RuntimeError is re-raised as CommandError, preserving the message."""
+        monkeypatch.setattr(_utils_module, "CommandError", _FakeCommandError)
+        msg = "some msg"
+
+        @reraise_for_klipper
+        def func() -> None:
+            raise RuntimeError(msg)
+
+        with pytest.raises(_FakeCommandError, match="some msg"):
+            func()
+
+    def test_reraise_for_klipper_passes_through_non_runtime_errors(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        """Exceptions that are not RuntimeError subclasses pass through unchanged."""
+        monkeypatch.setattr(_utils_module, "CommandError", _FakeCommandError)
+
+        @reraise_for_klipper
+        def func() -> None:
+            raise KeyError()
+
+        with pytest.raises(KeyError):
+            func()
+
+    # ------------------------------------------------------------------ #
+    # catch_macro_errors                                                  #
+    # ------------------------------------------------------------------ #
+
+    def test_catch_macro_errors_converts_printer_shutdown(self) -> None:
+        """PrinterShutdownError inside a macro handler becomes gcmd.error(shutdown msg)."""
+        gcmd = Mock()
+        gcmd.error = _FakeCommandError
+
+        @catch_macro_errors
+        def handler(_gcmd: object) -> None:
+            raise PrinterShutdownError()
+
+        with pytest.raises(_FakeCommandError, match="Aborted: printer entered shutdown"):
+            handler(gcmd)
+
+    def test_catch_macro_errors_converts_runtime_error(self) -> None:
+        """RuntimeError inside a macro handler becomes gcmd.error(msg)."""
+        gcmd = Mock()
+        gcmd.error = _FakeCommandError
+
+        msg = "runtime msg"
+
+        @catch_macro_errors
+        def handler(_gcmd: object) -> None:
+            raise RuntimeError(msg)
+
+        with pytest.raises(_FakeCommandError, match="runtime msg"):
+            handler(gcmd)
+
+    def test_catch_macro_errors_converts_value_error(self) -> None:
+        """ValueError inside a macro handler becomes gcmd.error(msg)."""
+        gcmd = Mock()
+        gcmd.error = _FakeCommandError
+
+        msg = "value msg"
+
+        @catch_macro_errors
+        def handler(_gcmd: object) -> None:
+            raise ValueError(msg)
+
+        with pytest.raises(_FakeCommandError, match="value msg"):
+            handler(gcmd)

--- a/tests/test_stream.py
+++ b/tests/test_stream.py
@@ -7,6 +7,7 @@ from typing import Callable
 import pytest
 from typing_extensions import override
 
+from cartographer.interfaces.errors import PrinterShutdownError
 from cartographer.stream import Condition, Stream
 
 
@@ -37,19 +38,19 @@ def stream() -> Stream[object]:
 
 
 class TestStream:
-    def test_start_session(self, stream: Stream[int]) -> None:
+    def test_start_session(self, stream: Stream[object]) -> None:
         with stream.start_session() as session:
             stream.add_item(42)
         assert session.get_items() == [42]
 
-    def test_start_session_with_condition(self, stream: Stream[int]) -> None:
+    def test_start_session_with_condition(self, stream: Stream[object]) -> None:
         with stream.start_session(start_condition=lambda x: x == 2) as session:
             stream.add_item(1)
             stream.add_item(2)
             stream.add_item(3)
         assert session.get_items() == [2, 3]
 
-    def test_wait_for(self, stream: Stream[int]) -> None:
+    def test_wait_for(self, stream: Stream[object]) -> None:
         session = stream.start_session()
 
         def add_items():
@@ -96,6 +97,24 @@ class TestSessionAbort:
         with pytest.raises(RuntimeError, match="disconnected"):
             session.wait_for(lambda items: False)
 
+    def test_abort_with_custom_error_raises_that_error(self, stream: Stream[object]) -> None:
+        """Passing a custom error to abort() causes wait_for to raise that exact error."""
+        session = stream.start_session()
+        custom_error = ValueError("custom error")
+        session.abort(custom_error)
+
+        with pytest.raises(ValueError, match="custom error"):
+            session.wait_for(lambda items: False)
+
+    def test_abort_with_printer_shutdown_error(self, stream: Stream[object]) -> None:
+        """Passing PrinterShutdownError to abort() causes wait_for to raise it."""
+        session = stream.start_session()
+        error = PrinterShutdownError()
+        session.abort(error)
+
+        with pytest.raises(PrinterShutdownError, match="Printer entered shutdown"):
+            session.wait_for(lambda items: False)
+
 
 class TestAbortAllSessions:
     def test_stream_abort_all_sessions_aborts_each(self, stream: Stream[object]) -> None:
@@ -114,3 +133,17 @@ class TestAbortAllSessions:
     def test_stream_abort_all_sessions_empty(self, stream: Stream[object]) -> None:
         """abort_all_sessions on a stream with no sessions does not raise."""
         stream.abort_all_sessions()  # Should not raise
+
+    def test_abort_all_sessions_with_error_propagates_to_all(self, stream: Stream[object]) -> None:
+        """A custom error passed to abort_all_sessions is raised by every active session."""
+        session_a = stream.start_session()
+        session_b = stream.start_session()
+        custom_error = ValueError("custom")
+
+        stream.abort_all_sessions(custom_error)
+
+        with pytest.raises(ValueError, match="custom"):
+            session_a.wait_for(lambda items: False)
+
+        with pytest.raises(ValueError, match="custom"):
+            session_b.wait_for(lambda items: False)


### PR DESCRIPTION
## Summary

When a printer enters shutdown (emergency stop), long-running macros continued indefinitely — either spinning on stale cached temperature data (visible as repeated "Temperature: 44.3°C" messages after "Klipper state: Shutdown") or blocking forever on session predicates that could never be satisfied.

This adds shutdown awareness to both blocking paths in the plugin:

1. **Stream sessions** — `_handle_shutdown()` now calls `abort_all_sessions()` with a typed `PrinterShutdownError`, waking all greenlets blocked in `session.wait_for()`. This mirrors what `_handle_disconnect()` already did.

2. **Scheduler** — `KlipperScheduler.sleep()` and `.wait_until()` check `printer.is_shutdown()` after each `reactor.pause()` return and raise `PrinterShutdownError`. Protects the temperature calibration polling loop, sensor-ready wait, and subprocess executor.

## Decisions & callouts

- **Two exception types**: `PrinterShutdownError` for shutdown, `McuDisconnectedError` for non-critical disconnect. Both are `RuntimeError` subclasses. `Session.abort(error)` stores and re-raises the provided error, so callers can distinguish by type.
- **Macro decorators convert to CommandError**: `_catch_macro_errors` and `@reraise_for_klipper` catch `PrinterShutdownError` and convert to `CommandError("Aborted: printer entered shutdown")`. This prevents Klipper's bare `except:` from logging a misleading "Internal error on command" traceback — the user sees a clean abort message instead.
- **`_handle_shutdown()` uses try/finally**: Ensures `abort_all_sessions()` fires even if `stop_streaming()` raises during teardown.
- **Scheduler takes `shutdown_check: Callable[[], bool]`**: Minimal dependency — just a predicate, no coupling to printer objects or protocols.
- **Scheduler moved to `klipper_like/`**: Was in `adapters/klipper/` but imported by all three adapter packages. Moved to the shared layer where it belongs.
- **`task_executor.py` resource cleanup**: Wrapped in try/finally so subprocess is terminated and pipe closed on any exit path.