### PR TITLE
fix(bed-mesh): scale scan sample assignment radius with grid spacing

### DIFF
--- a/src/cartographer/macros/bed_mesh/scan_mesh.py
+++ b/src/cartographer/macros/bed_mesh/scan_mesh.py
@@ -78,6 +78,68 @@ class BedMeshCalibrateConfiguration:
 
 _directions: list[str] = ["x", "y"]
 
+_MAX_INVALID_DIAGNOSTICS = 20
+
+
+def _compute_mesh_assignment_radius(grid: MeshGrid) -> float:
+    """Derive a bed-mesh-specific sample-assignment radius from grid spacing.
+
+    radius = max(1.0, min(min_spacing / 3.0, 5.0))
+
+    Falls back to 1.0 when no valid (positive) spacing exists (degenerate grid).
+    """
+    spacings = [spacing for spacing in (grid.x_step, grid.y_step) if spacing > 0]
+    if not spacings:
+        return 1.0
+    return max(1.0, min(min(spacings) / 3.0, 5.0))
+
+
+def _build_invalid_point_diagnostics(
+    invalid_points: list[tuple[Point, int]],
+    samples: list[Sample],
+) -> list[str]:
+    """Return per-point diagnostic lines for invalid grid points.
+
+    Only the first *_MAX_INVALID_DIAGNOSTICS* points are detailed; the remainder
+    are summarised in a single trailing line.  Each entry reports the nearest
+    raw-sample position and its distance.
+    """
+    sample_positions: list[tuple[float, float]] = [
+        (s.position.x, s.position.y) for s in samples if s.position is not None
+    ]
+
+    lines: list[str] = []
+    shown = min(len(invalid_points), _MAX_INVALID_DIAGNOSTICS)
+
+    for point, assigned in invalid_points[:shown]:
+        gx, gy = float(point[0]), float(point[1])
+        best_dist: float | None = None
+        best_sx: float = 0.0
+        best_sy: float = 0.0
+
+        for sx, sy in sample_positions:
+            dx = sx - gx
+            dy = sy - gy
+            dist = (dx * dx + dy * dy) ** 0.5
+            if best_dist is None or dist < best_dist:
+                best_dist = dist
+                best_sx = sx
+                best_sy = sy
+
+        if best_dist is not None:
+            lines.append(
+                f"  ({gx:.2f},{gy:.2f}) assigned={assigned}"
+                f" nearest=({best_sx:.2f},{best_sy:.2f}) dist={best_dist:.2f}mm"
+            )
+        else:
+            lines.append(f"  ({gx:.2f},{gy:.2f}) assigned={assigned} [no raw samples]")
+
+    omitted = len(invalid_points) - shown
+    if omitted > 0:
+        lines.append(f"  ... and {omitted} more invalid point(s) not shown")
+
+    return lines
+
 
 PATH_GENERATOR_MAP = {
     MeshPath.SNAKE: SnakePathGenerator,
@@ -309,34 +371,40 @@ class BedMeshCalibrateMacro(Macro, SupportsFallbackMacro):
     @log_duration("Processing samples into final mesh positions")
     def _process_samples_to_positions(self, grid: MeshGrid, samples: list[Sample], height: float) -> list[Position]:
         """Process samples into final mesh positions."""
-        sample_processor = SampleProcessor(grid)
+        assignment_radius = _compute_mesh_assignment_radius(grid)
+        sample_processor = SampleProcessor(grid, max_distance=assignment_radius)
 
         # Assign samples to grid points
         results = sample_processor.assign_samples_to_grid(samples, self.probe.scan.calculate_sample_distance)
 
         # Convert results to positions
-        positions = self._results_to_positions(results, height)
+        positions = self._results_to_positions(results, height, samples, assignment_radius)
         return self.coordinate_transformer.apply_faulty_regions(positions, self.config.faulty_regions)
 
-    def _results_to_positions(self, results: list[GridPointResult], height: float) -> list[Position]:
+    def _results_to_positions(
+        self, results: list[GridPointResult], height: float, samples: list[Sample], assignment_radius: float
+    ) -> list[Position]:
         """Convert grid results to Position objects."""
         positions: list[Position] = []
 
-        total_samples = sum(r.sample_count for r in results)
         invalid_points = [(r.point, r.sample_count) for r in results if not isfinite(r.z)]
         sparse_points = [(r.point, r.sample_count) for r in results if isfinite(r.z) and r.sample_count < 3]
 
         if invalid_points:
-            invalid_list = ", ".join(f"({p[0]:.2f},{p[1]:.2f}) samples={n}" for p, n in invalid_points)
-            lines = [
-                f"Mesh scan failed: {len(invalid_points)}/{len(results)} grid points have no valid samples.",
-                f"Total samples collected: {total_samples}.",
-                f"Invalid grid points: {invalid_list}.",
+            raw_count = len(samples)
+            assigned_count = sum(r.sample_count for r in results)
+            diag_lines = _build_invalid_point_diagnostics(invalid_points, samples)
+            msg_lines = [
+                f"Mesh scan failed: {len(invalid_points)}/{len(results)} grid points have no valid samples."
+                f" Raw samples: {raw_count}. Assigned to grid: {assigned_count}."
+                f" Assignment radius: {assignment_radius:.2f}mm.",
+                f"Invalid points ({len(invalid_points)} total):",
+                *diag_lines,
             ]
             if sparse_points:
                 sparse_list = ", ".join(f"({p[0]:.2f},{p[1]:.2f})={n}" for p, n in sparse_points)
-                lines.append(f"Sparse grid points (<3 samples): {sparse_list}.")
-            msg = " ".join(lines)
+                msg_lines.append(f"Sparse grid points (<3 samples): {sparse_list}.")
+            msg = "\n".join(msg_lines)
             logger.error(msg)
             raise RuntimeError(msg)
 

--- a/tests/macros/bed_mesh/test_scan_mesh.py
+++ b/tests/macros/bed_mesh/test_scan_mesh.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
 from dataclasses import dataclass, replace
-from typing import TYPE_CHECKING, final
+from typing import TYPE_CHECKING, cast, final
 
 import numpy as np
 import pytest
@@ -176,6 +176,42 @@ class TestBedMeshIntegration:
         macro = BedMeshCalibrateMacro(probe, toolhead, adapter, None, task_executor, mesh_config)
 
         return macro
+
+    def test_run_reports_invalid_point_sample_diagnostics(
+        self,
+        mocker: MockerFixture,
+        bed_mesh_macro: BedMeshCalibrateMacro,
+        probe_offset: Position,
+        params: MockParams,
+        session: Mock,
+    ):
+        """Invalid mesh errors include assignment radius and nearest-sample diagnostics."""
+        expected_probe_positions = [(float(10 + 20 * x), float(10 + 20 * y)) for x in range(5) for y in range(5)]
+        invalid_point = (90.0, 10.0)
+        valid_probe_positions = [point for point in expected_probe_positions if point != invalid_point]
+        # All three are > 5.0mm from (90,10) so they remain unassigned;
+        # 5x5 grid (10-90, step=20mm) → radius = max(1.0, min(20/3, 5.0)) = 5.0mm
+        near_invalid_positions = [(96.0, 10.0), (98.0, 10.0), (100.0, 10.0)]
+        probe_positions = valid_probe_positions + near_invalid_positions
+        heights = [0.5] * len(probe_positions)
+        mock_samples = self.create_samples_at_probe_positions(probe_positions, heights, probe_offset)
+        session.get_items = mocker.Mock(return_value=mock_samples)
+
+        params.params = {"METHOD": "scan"}
+        with pytest.raises(RuntimeError) as exc_info:
+            bed_mesh_macro.run(params)
+
+        msg = str(exc_info.value)
+        assert "Mesh scan failed: 1/25 grid points have no valid samples." in msg
+        assert "Raw samples: 27. Assigned to grid: 24." in msg
+        assert "Assignment radius: 5.00mm." in msg
+        assert "Invalid points (1 total):" in msg
+        assert "(90.00,10.00) assigned=0 nearest=(96.00,10.00) dist=6.00mm" in msg
+        # Concise format: no within_2mm/within_5mm proximity counts
+        assert "within_2mm" not in msg
+        assert "within_5mm" not in msg
+        # No generated-path waypoint/segment diagnostics
+        assert "path: wp#" not in msg
 
     def test_regular_mesh_boundary_and_coordinate_transformation(
         self,
@@ -369,3 +405,68 @@ class TestBedMeshIntegration:
         # Check that all expected nozzle positions were visited
         missing = expected_nozzle_positions - actual_move_positions
         assert not missing, f"Missing expected nozzle moves: {missing}"
+
+    @pytest.mark.parametrize(
+        "mesh_max, sample_offset",
+        [
+            ((20.0, 20.0), 2.0),  # step=10mm → radius≈3.33mm; offset=2mm is > 1.0mm default but < 3.33mm
+            ((30.0, 30.0), 3.0),  # step=15mm → radius=5.0mm;  offset=3mm is > 1.0mm default but < 5.0mm
+        ],
+    )
+    def test_spacing_derived_radius_accepts_samples_outside_1mm(
+        self,
+        mocker: MockerFixture,
+        probe_offset: Position,
+        params: MockParams,
+        session: Mock,
+        toolhead: MockToolhead,
+        adapter: MockBedMeshAdapter,
+        mesh_max: tuple[float, float],
+        sample_offset: float,
+    ):
+        """Mesh with spacing-derived radius accepts samples beyond the 1mm default.
+
+        The 3x3 grids used here produce steps of 10mm and 15mm respectively.
+        Assignment radii are max(1.0, min(step/3, 5.0)) = ~3.33mm and 5.0mm.
+        Samples placed *sample_offset* mm off each grid point (outside the old
+        1.0mm default but inside the derived radius) must all be accepted so
+        that the mesh completes without a RuntimeError.
+        """
+        step = mesh_max[0] / 2  # spacing for a 3-point axis spanning 0..mesh_max[0]
+        zero_ref: tuple[float, float] = (step, step)  # centre of the 3x3 grid
+        mesh_cfg = BedMeshCalibrateConfiguration(
+            mesh_min=(0.0, 0.0),
+            mesh_max=mesh_max,
+            probe_count=(3, 3),
+            speed=100.0,
+            adaptive_margin=5.0,
+            zero_reference_position=zero_ref,
+            runs=1,
+            direction="x",
+            height=2.0,
+            path=MeshPath.SNAKE,
+            faulty_regions=[],
+        )
+        task_executor = InlineTaskExecutor()
+        macro = BedMeshCalibrateMacro(
+            cast("Probe", cast("object", MockProbe(session, probe_offset))),
+            cast("Toolhead", cast("object", toolhead)),
+            adapter,
+            None,
+            task_executor,
+            mesh_cfg,
+        )
+
+        # Grid points: (0,0), (step,0), (2*step,0), ..., (2*step, 2*step)
+        grid_points = [(float(x * step), float(y * step)) for x in range(3) for y in range(3)]
+        # Shift each probe position by sample_offset in x — outside 1.0mm but inside derived radius
+        probe_positions = [(px + sample_offset, py) for px, py in grid_points]
+        heights = [0.5] * len(probe_positions)
+        mock_samples = self.create_samples_at_probe_positions(probe_positions, heights, probe_offset)
+        session.get_items = mocker.Mock(return_value=mock_samples)
+
+        params.params = {"METHOD": "scan"}
+        # Must not raise — all 9 grid points should receive an assigned sample
+        macro.run(params)
+
+        assert len(adapter.mesh_positions) == 9


### PR DESCRIPTION
## Summary
Fixes bed mesh scan assignment by deriving the sample assignment radius from mesh grid spacing instead of using the fixed 1.0mm default. The bed mesh scan path can legitimately collect samples just outside 1mm from exact grid points around turns or final endpoints, especially on 10–15mm grids.

The assignment radius is now:

```text
max(1.0, min(min_grid_spacing / 3.0, 5.0))
```

This keeps dense meshes at least as strict as before, scales tolerance for normal scan meshes, and caps sparse meshes at 5mm.

## Diagnostics retained
The failure message remains concise but includes enough context for support:

- raw sample count
- assigned sample count
- assignment radius
- capped invalid-point list with nearest raw sample position and distance

Generated-path waypoint/segment diagnostics were removed after testing confirmed the generated path already reaches the affected points.

## Install command

```
~/klippy-env/bin/pip install --no-cache-dir --force-reinstall "git+https://github.com/Cartographer3D/cartographer3d-plugin.git@bed-mesh-failure-diagnostics"
sudo systemctl restart klipper
```

To revert to the latest stable release:

```
~/klippy-env/bin/pip install --no-cache-dir --force-reinstall cartographer3d-plugin
sudo systemctl restart klipper
```

## Manual testing
- [ ] Install this branch on the affected printer and run the failing `BED_MESH_CALIBRATE` command.
- [ ] Confirm the mesh completes, or if it still fails, confirm the failure log includes `Assignment radius` and nearest-sample distances.

## Automated validation
- [x] `uv run pytest -q tests/macros/bed_mesh/test_scan_mesh.py`
- [x] `uv run ruff check`
- [x] `uv run basedpyright`
- [x] `uv run pytest -q`