### PR TITLE
feat: add scan mesh max corner radius control

### DIFF
--- a/scripts/plot_path.py
+++ b/scripts/plot_path.py
@@ -4,11 +4,10 @@
 # pyright: reportUnknownParameterType=false
 from __future__ import annotations
 
-import sys
+import argparse
 from typing import TYPE_CHECKING
 
 import matplotlib.pyplot as plt
-from matplotlib.animation import FuncAnimation
 
 from cartographer.macros.bed_mesh.paths.alternating_snake import AlternatingSnakePathGenerator
 from cartographer.macros.bed_mesh.paths.random_path import RandomPathGenerator
@@ -16,71 +15,10 @@ from cartographer.macros.bed_mesh.paths.snake_path import SnakePathGenerator
 from cartographer.macros.bed_mesh.paths.spiral_path import SpiralPathGenerator
 
 if TYPE_CHECKING:
-    from matplotlib.text import Annotation
+    from matplotlib.axes import Axes
+    from matplotlib.figure import Figure
 
     from cartographer.macros.bed_mesh.interfaces import PathGenerator, Point
-
-
-def make_grid(nx: int, ny: int, spacing: float) -> list[Point]:
-    return [(1 + x * spacing, 1 + y * spacing) for y in range(ny) for x in range(nx)]
-
-
-def plot_grid_and_path(ax, name: str, grid: list[Point], path: list[Point]):
-    # Plot all grid points as light gray background dots
-    gx, gy = zip(*grid)
-    ax.scatter(gx, gy, color="red", s=20, label="Grid")
-
-    # Plot path as blue line
-    px, py = zip(*path)
-    ax.plot(px, py, linestyle="-", color="blue", label="Path")
-
-    ax.set_title(name)
-    ax.set_aspect("equal")
-    ax.grid(True)
-
-
-def animate_paths(generator: PathGenerator, grid_shapes: list[tuple[int, int]], spacing=5, interval=300):
-    fig, axes = plt.subplots(nrows=(len(grid_shapes) + 2) // 3, ncols=3, figsize=(16, 10))
-    axes = axes.flatten()
-
-    all_grids: list[list[Point]] = []
-    all_paths: list[list[Point]] = []
-    arrows: list[Annotation] = []
-
-    # Prepare plots & arrows
-    for ax, (nx, ny) in zip(axes, grid_shapes):
-        grid = make_grid(nx, ny, spacing)
-        path = list(generator.generate_path(grid, (0, nx * spacing + 2), (0, ny * spacing + 2)))
-        plot_grid_and_path(ax, f"{nx}×{ny} grid", grid, path)
-        all_grids.append(grid)
-        all_paths.append(path)
-
-        # Create arrow annotation at start of path
-        arrow = ax.annotate(
-            "",
-            xy=path[0],
-            arrowprops=dict(
-                arrowstyle="->",
-                color="red",
-                lw=2,
-            ),
-        )
-        arrows.append(arrow)
-
-    for ax in axes[len(grid_shapes) :]:
-        ax.axis("off")
-
-    def update(frame: int):
-        for arrow, path in zip(arrows, all_paths):
-            i = frame % len(path)  # Loop through frames
-            arrow.set_position(xy=(float(path[i - 1][0]), float(path[i - 1][1])))
-            arrow.xy = (float(path[i][0]), float(path[i][1]))
-        return arrows
-
-    _ = FuncAnimation(fig, update, interval=interval, blit=True)
-    plt.tight_layout()
-    plt.show()
-
 
 PATH_STRATEGY_MAP = {
     "snake": SnakePathGenerator,
@@ -89,22 +27,221 @@ PATH_STRATEGY_MAP = {
     "random": RandomPathGenerator,
 }
 
+# ---------------------------------------------------------------------------
+# Grid / axis helpers
+# ---------------------------------------------------------------------------
+
+
+def make_grid(nx: int, ny: int, spacing: float) -> list[Point]:
+    """Return a flat list of (x, y) grid points ordered row by row."""
+    return [(1.0 + x * spacing, 1.0 + y * spacing) for y in range(ny) for x in range(nx)]
+
+
+def make_axis_limits(
+    grid: list[Point],
+    padding: float,
+) -> tuple[tuple[float, float], tuple[float, float]]:
+    """Return x- and y-axis limits with *padding* beyond the grid extents."""
+    xs = [float(p[0]) for p in grid]
+    ys = [float(p[1]) for p in grid]
+    return (min(xs) - padding, max(xs) + padding), (min(ys) - padding, max(ys) + padding)
+
+
+# ---------------------------------------------------------------------------
+# Drawing
+# ---------------------------------------------------------------------------
+
+
+def draw_grid_and_path(ax: Axes, title: str, grid: list[Point], path: list[Point]) -> None:
+    """Draw grid points, path line, direction arrows, and start/end markers onto *ax*."""
+    if not path:
+        ax.set_title(title)
+        return
+
+    # Grid points
+    gx = [float(p[0]) for p in grid]
+    gy = [float(p[1]) for p in grid]
+    ax.scatter(gx, gy, color="lightgray", edgecolors="gray", s=20, zorder=2, label="Grid")
+
+    # Path line
+    px = [float(p[0]) for p in path]
+    py = [float(p[1]) for p in path]
+    ax.plot(px, py, linestyle="-", color="steelblue", lw=1.2, zorder=1)
+
+    # Direction arrows spaced evenly along the path
+    if len(path) >= 2:
+        n_arrows = min(10, len(path) - 1)
+        step = max(1, (len(path) - 1) // n_arrows)
+        for i in range(0, len(path) - 1, step):
+            ax.annotate(
+                "",
+                xy=(float(path[i + 1][0]), float(path[i + 1][1])),
+                xytext=(float(path[i][0]), float(path[i][1])),
+                arrowprops={"arrowstyle": "->", "color": "steelblue", "lw": 1.0},
+                zorder=3,
+            )
+
+    # Start / end markers
+    ax.plot(float(path[0][0]), float(path[0][1]), "go", ms=6, zorder=4, label="Start")
+    ax.plot(float(path[-1][0]), float(path[-1][1]), "rs", ms=6, zorder=4, label="End")
+
+    ax.set_title(title)
+    ax.set_aspect("equal")
+    ax.grid(True, alpha=0.3)
+    ax.legend(loc="upper right", fontsize=8)
+
+
+# ---------------------------------------------------------------------------
+# Renderer
+# ---------------------------------------------------------------------------
+
+
+def render_single(
+    generator: PathGenerator,
+    nx: int,
+    ny: int,
+    spacing: float,
+    axis_padding: float,
+    strategy_name: str,
+) -> Figure:
+    """Render a single grid and return the figure."""
+    fig, ax = plt.subplots(figsize=(8, 8))
+    grid = make_grid(nx, ny, spacing)
+    x_lim, y_lim = make_axis_limits(grid, axis_padding)
+    path = list(generator.generate_path(grid, x_lim, y_lim))
+    draw_grid_and_path(ax, f"{strategy_name}  {nx}×{ny}", grid, path)
+    plt.tight_layout()
+    return fig
+
+
+# ---------------------------------------------------------------------------
+# Argument parsing
+# ---------------------------------------------------------------------------
+
+
+def parse_grid(value: str) -> tuple[int, int]:
+    """Argparse type converter for 'NxM' grid specs (e.g. ``5x5``)."""
+    parts = value.lower().split("x")
+    if len(parts) != 2:
+        msg = f"grid must be NxM (e.g. 5x5), got {value!r}"
+        raise argparse.ArgumentTypeError(msg)
+    try:
+        nx, ny = int(parts[0]), int(parts[1])
+    except ValueError as exc:
+        msg = f"grid dimensions must be integers, got {value!r}"
+        raise argparse.ArgumentTypeError(msg) from exc
+    if nx < 1 or ny < 1:
+        msg = f"grid dimensions must be >= 1, got {value!r}"
+        raise argparse.ArgumentTypeError(msg)
+    return nx, ny
+
+
+def parse_max_corner_radius(value: str) -> float | None:
+    """Argparse type converter: ``'auto'`` → ``None``, numeric string → non-negative float."""
+    if value.lower() == "auto":
+        return None
+    try:
+        f = float(value)
+    except ValueError as exc:
+        msg = f"--max-corner-radius must be 'auto' or a non-negative float, got {value!r}"
+        raise argparse.ArgumentTypeError(msg) from exc
+    if f < 0:
+        msg = f"--max-corner-radius must be non-negative, got {f}"
+        raise argparse.ArgumentTypeError(msg)
+    return f
+
+
+def build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(
+        prog="plot_path.py",
+        description="Visualise Cartographer3D bed mesh path strategies.",
+        formatter_class=argparse.RawDescriptionHelpFormatter,
+        epilog="""\
+examples:
+  python scripts/plot_path.py snake
+  python scripts/plot_path.py snake --grid 7x7 --max-corner-radius 0 --output snake.png
+  python scripts/plot_path.py spiral --grid 9x8 --max-corner-radius auto
+""",
+    )
+    parser.add_argument(
+        "strategy",
+        choices=list(PATH_STRATEGY_MAP),
+        help="Path generation strategy.",
+    )
+    parser.add_argument(
+        "--direction",
+        choices=["x", "y"],
+        default="x",
+        metavar="{x,y}",
+        help="Primary scan direction (ignored by spiral and random). Default: x",
+    )
+    parser.add_argument(
+        "--max-corner-radius",
+        metavar="VALUE",
+        default=None,
+        type=parse_max_corner_radius,
+        dest="max_corner_radius",
+        help="Corner-radius cap: 'auto' or a non-negative float. Omit for auto.",
+    )
+    parser.add_argument(
+        "--grid",
+        metavar="NXxNY",
+        default="5x5",
+        type=parse_grid,
+        help="Grid size. Default: 5x5",
+    )
+    parser.add_argument(
+        "--spacing",
+        metavar="FLOAT",
+        default=5.0,
+        type=float,
+        help="Point-to-point spacing. Default: 5",
+    )
+    parser.add_argument(
+        "--axis-padding",
+        metavar="FLOAT",
+        default=2.0,
+        dest="axis_padding",
+        type=float,
+        help="Axis padding beyond grid extents. Default: 2",
+    )
+    parser.add_argument(
+        "--output",
+        metavar="PATH",
+        default=None,
+        help="Save static image (PNG, PDF, SVG, ...).",
+    )
+    parser.add_argument(
+        "--show",
+        action="store_true",
+        help="Force interactive display even when --output is given.",
+    )
+    return parser
+
+
+# ---------------------------------------------------------------------------
+# Entry point
+# ---------------------------------------------------------------------------
+
+
+def main(argv: list[str] | None = None) -> None:
+    parser = build_parser()
+    args = parser.parse_args(argv)
+
+    strategy_cls = PATH_STRATEGY_MAP[args.strategy]
+    generator: PathGenerator = strategy_cls(args.direction, args.max_corner_radius)
+
+    nx, ny = args.grid  # tuple[int, int] from parse_grid
+
+    fig = render_single(generator, nx, ny, args.spacing, args.axis_padding, args.strategy)
+
+    if args.output is not None:
+        fig.savefig(args.output, dpi=150, bbox_inches="tight")
+        print(f"Saved to {args.output!r}")
+
+    if args.show or args.output is None:
+        plt.show()
+
+
 if __name__ == "__main__":
-    path_strategy_type = sys.argv[1]
-    path_strategy = PATH_STRATEGY_MAP.get(path_strategy_type)
-    if path_strategy is None:
-        msg = f"Unknown path strategy: {path_strategy_type}"
-        raise ValueError(msg)
-    generator = path_strategy("x")
-
-    grid_shapes = [
-        (3, 3),
-        (4, 4),
-        (5, 3),
-        (6, 4),
-        (10, 11),
-        (7, 11),
-        (9, 8),
-    ]
-
-    animate_paths(generator, grid_shapes)
+    main()

--- a/src/cartographer/interfaces/configuration.py
+++ b/src/cartographer/interfaces/configuration.py
@@ -132,6 +132,28 @@ def _parse_scan_domain(config: ConfigWrapper) -> tuple[float, float]:
     return _list_to_tuple(config.getfloatlist("domain", count=2))
 
 
+def _parse_mesh_max_corner_radius(config: ConfigWrapper) -> float | None:
+    raw = config.get("mesh_max_corner_radius", default=None)
+    if raw is None:
+        return None
+
+    value = raw.strip()
+    if value.lower() == "auto":
+        return None
+
+    try:
+        radius = float(value)
+    except ValueError:
+        msg = f"mesh_max_corner_radius must be 'auto' or a non-negative number, got {raw!r}"
+        raise ValueError(msg) from None
+
+    if radius < 0:
+        msg = f"mesh_max_corner_radius must be 'auto' or a non-negative number, got {radius}"
+        raise ValueError(msg)
+
+    return radius
+
+
 @dataclass(frozen=True)
 class GeneralConfig:
     config_section_key: ClassVar[str] = "cartographer"
@@ -180,6 +202,14 @@ class ScanConfig:
     mesh_path: MeshPath = option(
         "The path to use when calibrating a scan mesh.",
         default=MeshPath.SNAKE,
+    )
+    mesh_max_corner_radius: float | None = option(
+        "Maximum corner radius (mm) for scan mesh path arcs."
+        " Omit or set to 'auto' to derive the radius from point spacing and axis limits;"
+        " 0 disables smoothing arcs;"
+        " positive values cap the auto-computed radius.",
+        default=None,
+        parse_fn=_parse_mesh_max_corner_radius,
     )
     models: dict[str, ScanModelConfiguration] = field(default_factory=dict)  # provided via override
 

--- a/src/cartographer/macros/bed_mesh/paths/alternating_snake.py
+++ b/src/cartographer/macros/bed_mesh/paths/alternating_snake.py
@@ -13,8 +13,9 @@ if TYPE_CHECKING:
 
 @final
 class AlternatingSnakePathGenerator(PathGenerator):
-    def __init__(self, main_direction: str):
+    def __init__(self, main_direction: str, max_corner_radius: float | None = None):
         self.main_direction: str = main_direction
+        self.max_corner_radius: float | None = max_corner_radius
 
     @override
     def generate_path(
@@ -24,7 +25,7 @@ class AlternatingSnakePathGenerator(PathGenerator):
         y_axis_limits: tuple[float, float],
     ) -> Iterator[Point]:
         alternate_direction = "y" if self.main_direction == "x" else "x"
-        main_path = SnakePathGenerator(self.main_direction)
-        alternate_path = SnakePathGenerator(alternate_direction)
+        main_path = SnakePathGenerator(self.main_direction, self.max_corner_radius)
+        alternate_path = SnakePathGenerator(alternate_direction, self.max_corner_radius)
         yield from main_path.generate_path(points, x_axis_limits, y_axis_limits)
         yield from reversed(list(alternate_path.generate_path(points, x_axis_limits, y_axis_limits)))

--- a/src/cartographer/macros/bed_mesh/paths/random_path.py
+++ b/src/cartographer/macros/bed_mesh/paths/random_path.py
@@ -16,8 +16,8 @@ MIN_DIST = 10.0
 
 @final
 class RandomPathGenerator(PathGenerator):
-    def __init__(self, main_direction: str):
-        del main_direction
+    def __init__(self, main_direction: str, max_corner_radius: float | None = None):
+        del main_direction, max_corner_radius
 
     @override
     def generate_path(

--- a/src/cartographer/macros/bed_mesh/paths/snake_path.py
+++ b/src/cartographer/macros/bed_mesh/paths/snake_path.py
@@ -9,6 +9,7 @@ from cartographer.macros.bed_mesh.interfaces import PathGenerator
 from cartographer.macros.bed_mesh.paths.utils import (
     Vec,
     angle_deg,
+    apply_corner_radius_cap,
     arc_points,
     cluster_points,
     normalize,
@@ -24,8 +25,9 @@ BUFFER = 0.5
 
 @final
 class SnakePathGenerator(PathGenerator):
-    def __init__(self, main_direction: str):
+    def __init__(self, main_direction: str, max_corner_radius: float | None = None):
         self.main_direction: str = main_direction
+        self.max_corner_radius: float | None = max_corner_radius
 
     @override
     def generate_path(
@@ -47,8 +49,10 @@ class SnakePathGenerator(PathGenerator):
         mesh_max = grid[-1][-1][main_index]
         max_radius_by_bounds = min(mesh_min - axis_min, axis_max - mesh_max) - BUFFER
 
-        # Final corner radius
-        corner_radius = float(max(0, min(max_radius_by_spacing, max_radius_by_bounds)))
+        # Auto corner radius (clamped to valid range)
+        auto_radius = float(max(0, min(max_radius_by_spacing, max_radius_by_bounds)))
+
+        effective_radius = apply_corner_radius_cap(auto_radius, self.max_corner_radius)
 
         prev_row = grid[0]
 
@@ -60,9 +64,8 @@ class SnakePathGenerator(PathGenerator):
             if i > 0:
                 prev_last = prev_row[-1]
                 curr_first = row[0]
-                entry_dir = row_direction(prev_row[-2:])  # You must define this separately
-
-                yield from u_turn(prev_last, curr_first, entry_dir, corner_radius)
+                entry_dir = row_direction(prev_row[-2:])
+                yield from u_turn(prev_last, curr_first, entry_dir, effective_radius)
 
             yield from row
             prev_row = row

--- a/src/cartographer/macros/bed_mesh/paths/spiral_path.py
+++ b/src/cartographer/macros/bed_mesh/paths/spiral_path.py
@@ -9,6 +9,7 @@ from cartographer.macros.bed_mesh.interfaces import PathGenerator
 from cartographer.macros.bed_mesh.paths.utils import (
     Vec,
     angle_deg,
+    apply_corner_radius_cap,
     arc_points,
     cluster_points,
     normalize,
@@ -23,8 +24,9 @@ BUFFER = 0.5
 
 @final
 class SpiralPathGenerator(PathGenerator):
-    def __init__(self, main_direction: str):
+    def __init__(self, main_direction: str, max_corner_radius: float | None = None):
         del main_direction
+        self.max_corner_radius: float | None = max_corner_radius
 
     @override
     def generate_path(
@@ -42,8 +44,8 @@ class SpiralPathGenerator(PathGenerator):
         mesh_max_x, mesh_max_y = grid[-1][-1]
         max_radius_x = min(mesh_min_x - x_axis_limits[0], x_axis_limits[1] - mesh_max_x) - BUFFER
         max_radius_y = min(mesh_min_y - y_axis_limits[0], y_axis_limits[1] - mesh_max_y) - BUFFER
-        corner_radius = float(max(0, min(max_radius_x, max_radius_y, 1))) * 2
-        print(corner_radius)
+        auto_radius = float(max(0, min(max_radius_x, max_radius_y, 1)))
+        effective_radius = apply_corner_radius_cap(auto_radius, self.max_corner_radius)
 
         while offset < (rows + 1) // 2 and offset < (cols + 1) // 2:
             bottom = grid[offset][offset : cols - offset]
@@ -56,21 +58,21 @@ class SpiralPathGenerator(PathGenerator):
             # === Bottom row (→)
             if right or top or left:
                 yield from bottom[:-1]
-                yield from corner(bottom[-1], (1.0, 0.0), corner_radius)
+                yield from corner(bottom[-1], (1.0, 0.0), effective_radius)
             else:
                 yield from bottom  # Last leg, include final point
 
             # === Right column (↑)
             if top or left:
                 yield from right[:-1]
-                yield from corner(right[-1], (0.0, 1.0), corner_radius)
+                yield from corner(right[-1], (0.0, 1.0), effective_radius)
             else:
                 yield from right
 
             # === Top row (←)
             if left:
                 yield from top[:-1]
-                yield from corner(top[-1], (-1.0, 0.0), corner_radius)
+                yield from corner(top[-1], (-1.0, 0.0), effective_radius)
             else:
                 yield from top
 
@@ -80,7 +82,7 @@ class SpiralPathGenerator(PathGenerator):
                     # There will be another ring → add corner
                     if left:
                         yield from left[:-1]
-                        yield from corner(left[-1], (0.0, -1.0), corner_radius)
+                        yield from corner(left[-1], (0.0, -1.0), effective_radius)
                 else:
                     # Final leg
                     yield from left

--- a/src/cartographer/macros/bed_mesh/paths/utils.py
+++ b/src/cartographer/macros/bed_mesh/paths/utils.py
@@ -81,3 +81,21 @@ def row_direction(row: list[Point]) -> Vec:
     p1: Vec = np.asarray(row[1], dtype=float)
     dir_vec = p1 - p0
     return dir_vec / np.linalg.norm(dir_vec)  # normalized
+
+
+def apply_corner_radius_cap(auto_radius: float, max_corner_radius: float | None) -> float:
+    """Apply max_corner_radius config cap to an auto-computed corner radius.
+
+    Semantics:
+      - None  → use the auto radius unchanged (existing behaviour)
+      -   0   → disable arcs; return 0.0
+      -  >0   → return min(auto_radius, max_corner_radius)
+
+    The auto radius is defensively clamped to >=0 before applying the cap.
+    When ``max_corner_radius == 0``, the general ``min(auto_radius, max_corner_radius)``
+    expression returns 0, so no special-case branch is needed.
+    """
+    auto_radius = max(0.0, auto_radius)
+    if max_corner_radius is None:
+        return auto_radius
+    return min(auto_radius, max_corner_radius)

--- a/src/cartographer/macros/bed_mesh/scan_mesh.py
+++ b/src/cartographer/macros/bed_mesh/scan_mesh.py
@@ -44,6 +44,31 @@ if TYPE_CHECKING:
 logger = logging.getLogger(__name__)
 
 
+def _parse_max_corner_radius(value: str, name: str) -> float | None:
+    stripped = value.strip()
+    if stripped.lower() == "auto":
+        return None
+
+    try:
+        radius = float(stripped)
+    except ValueError:
+        msg = f"{name} must be 'auto' or a non-negative number, got {value!r}"
+        raise ValueError(msg) from None
+
+    if radius < 0:
+        msg = f"{name} must be 'auto' or a non-negative number, got {radius}"
+        raise ValueError(msg)
+
+    return radius
+
+
+def _get_max_corner_radius(params: MacroParams, config_default: float | None) -> float | None:
+    value = params.get("MAX_CORNER_RADIUS", default=None)
+    if value is None:
+        return config_default
+    return _parse_max_corner_radius(value, "MAX_CORNER_RADIUS")
+
+
 @dataclass(frozen=True)
 class BedMeshCalibrateConfiguration:
     mesh_min: tuple[float, float]
@@ -58,6 +83,7 @@ class BedMeshCalibrateConfiguration:
     direction: str
     height: float
     path: MeshPath
+    max_corner_radius: float | None = None
 
     @staticmethod
     def from_config(config: Configuration):
@@ -72,6 +98,7 @@ class BedMeshCalibrateConfiguration:
             direction=config.scan.mesh_direction,
             height=config.scan.mesh_height,
             path=config.scan.mesh_path,
+            max_corner_radius=config.scan.mesh_max_corner_radius,
             faulty_regions=list(map(lambda r: Region(r[0], r[1]), config.bed_mesh.faulty_regions)),
         )
 
@@ -113,6 +140,11 @@ class BedMeshScanAllParams:
     speed: float = param("Scan speed", default=config_ref(BedMeshConfig, "speed"), min=50)
     height: float = param("Scan height", default=config_ref(ScanConfig, "mesh_height"), min=0.5, max=5)
     runs: int = param("Number of scan passes", default=config_ref(ScanConfig, "mesh_runs"), min=1)
+    max_corner_radius: str | None = param(
+        "Maximum corner radius (mm) for scan path arcs."
+        " Use AUTO for automatic radius, 0 to disable smoothing arcs, or a positive number to cap auto radius.",
+        default=None,
+    )
 
 
 @dataclass
@@ -156,7 +188,8 @@ class MeshScanParams:
         # Create path generator
         direction: str = get_choice(params, "DIRECTION", _directions, default=config.direction)
         path_type = get_choice(params, "PATH", default=config.path, choices=PATH_GENERATOR_MAP.keys())
-        path_generator = PATH_GENERATOR_MAP[path_type](direction)
+        max_corner_radius = _get_max_corner_radius(params, config.max_corner_radius)
+        path_generator = PATH_GENERATOR_MAP[path_type](direction, max_corner_radius)
 
         return cls(
             mesh_bounds=mesh_bounds,

--- a/tests/config/test_mesh_max_corner_radius.py
+++ b/tests/config/test_mesh_max_corner_radius.py
@@ -1,0 +1,41 @@
+from __future__ import annotations
+
+from typing import TYPE_CHECKING, cast
+
+import pytest
+
+from cartographer.config.fields import parse
+from cartographer.interfaces.configuration import ScanConfig
+from tests.config.test_fields import MockConfigWrapper
+
+if TYPE_CHECKING:
+    from configfile import ConfigWrapper
+
+
+def parse_scan_config(value: str | None) -> ScanConfig:
+    data = {} if value is None else {"mesh_max_corner_radius": value}
+    config = MockConfigWrapper(data)
+    return parse(ScanConfig, cast("ConfigWrapper", cast("object", config)), models={})
+
+
+@pytest.mark.parametrize("value", [None, "auto", "AUTO", " Auto "])
+def test_mesh_max_corner_radius_auto_values_parse_to_none(value: str | None) -> None:
+    assert parse_scan_config(value).mesh_max_corner_radius is None
+
+
+@pytest.mark.parametrize(
+    ("value", "expected"),
+    [
+        ("0", 0.0),
+        ("2", 2.0),
+        ("2.5", 2.5),
+    ],
+)
+def test_mesh_max_corner_radius_numeric_values_parse_to_float(value: str, expected: float) -> None:
+    assert parse_scan_config(value).mesh_max_corner_radius == expected
+
+
+@pytest.mark.parametrize("value", ["-1", "nope"])
+def test_mesh_max_corner_radius_rejects_invalid_values(value: str) -> None:
+    with pytest.raises(ValueError):
+        _ = parse_scan_config(value)

--- a/tests/macros/bed_mesh/test_path_generators.py
+++ b/tests/macros/bed_mesh/test_path_generators.py
@@ -6,9 +6,11 @@ import numpy as np
 import pytest
 from typing_extensions import TypeAlias
 
+from cartographer.macros.bed_mesh.paths.alternating_snake import AlternatingSnakePathGenerator
 from cartographer.macros.bed_mesh.paths.random_path import RandomPathGenerator
 from cartographer.macros.bed_mesh.paths.snake_path import SnakePathGenerator
 from cartographer.macros.bed_mesh.paths.spiral_path import SpiralPathGenerator
+from cartographer.macros.bed_mesh.paths.utils import apply_corner_radius_cap
 
 if TYPE_CHECKING:
     from cartographer.macros.bed_mesh.interfaces import PathGenerator, Point
@@ -71,3 +73,123 @@ def test_path_generator_covers_all_points(generator: GeneratorFixture, grid_poin
     for p0, p1 in zip(path, path[1:]):
         dist = np.linalg.norm(np.asarray(p1) - np.asarray(p0))
         assert dist <= max_step, f"{gen_name} discontinuity {dist:.2f} on {grid_name}"
+
+
+# ---------------------------------------------------------------------------
+# Corner-radius unit tests
+# ---------------------------------------------------------------------------
+
+# 3×3 grid at 20 mm spacing: x,y ∈ {0, 20, 40}.  With axis limits (-10, 50):
+#   snake  auto-radius ≈ 9.5 mm  (bounded by min(0−(−10), 50−40) − 0.5 = 9.5)
+#   spiral auto-radius = 1.0 mm  (hard cap at 1 mm; no doubling)
+_CR_GRID: list[Point] = make_grid(3, 3, 20.0)
+_CR_X_LIM = (-10.0, 50.0)
+_CR_Y_LIM = (-10.0, 50.0)
+_MESH_MAX_X = 40.0  # rightmost grid x
+
+
+def _all_path_points_in_grid(path: list[Point], grid: list[Point], tol: float = 0.01) -> bool:
+    """Return True iff every path point lies within *tol* of some grid point."""
+    grid_arr = np.asarray(grid)
+    return all(np.min(np.linalg.norm(grid_arr - np.asarray(pt), axis=1)) <= tol for pt in path)
+
+
+class TestMaxCornerRadius:
+    """mesh_max_corner_radius / MAX_CORNER_RADIUS semantics for path generators."""
+
+    # --- SnakePathGenerator ---
+
+    def test_snake_default_generates_arc_points(self):
+        gen = SnakePathGenerator("x", max_corner_radius=None)
+        path = list(gen.generate_path(_CR_GRID, _CR_X_LIM, _CR_Y_LIM))
+        # auto-radius ~9.5 mm → u-turn arcs add extra off-grid points
+        assert len(path) > len(_CR_GRID), "auto radius should generate arc points"
+        assert not _all_path_points_in_grid(path, _CR_GRID), "arcs should produce off-grid points"
+
+    def test_snake_zero_radius_no_arcs(self):
+        gen = SnakePathGenerator("x", max_corner_radius=0.0)
+        path = list(gen.generate_path(_CR_GRID, _CR_X_LIM, _CR_Y_LIM))
+        assert _all_path_points_in_grid(path, _CR_GRID), "all points should be grid points (duplicates allowed)"
+
+    def test_snake_positive_cap_limits_overshoot(self):
+        cap = 2.0
+        gen = SnakePathGenerator("x", max_corner_radius=cap)
+        path = list(gen.generate_path(_CR_GRID, _CR_X_LIM, _CR_Y_LIM))
+        # arcs still exist
+        assert len(path) > len(_CR_GRID), "positive cap should still generate arc points"
+        # u-turn arcs for x-direction snake extend along x beyond mesh_max_x by ~radius
+        max_x = max(float(pt[0]) for pt in path)
+        assert max_x <= _MESH_MAX_X + cap + 0.1, f"x overshoot {max_x:.3f} exceeds cap {cap} + mesh_max {_MESH_MAX_X}"
+        # auto-radius would reach ~49.5; ensure cap actually constrained it
+        auto_max_x = _MESH_MAX_X + 9.5
+        assert max_x < auto_max_x - 1.0, (
+            f"cap {cap} did not constrain overshoot: {max_x:.3f} close to auto {auto_max_x:.3f}"
+        )
+
+    # --- AlternatingSnakePathGenerator ---
+
+    def test_alternating_snake_zero_radius_no_arcs(self):
+        gen = AlternatingSnakePathGenerator("x", max_corner_radius=0.0)
+        path = list(gen.generate_path(_CR_GRID, _CR_X_LIM, _CR_Y_LIM))
+        assert _all_path_points_in_grid(path, _CR_GRID), "alternating snake with radius=0 should yield only grid points"
+
+    def test_alternating_snake_default_generates_arc_points(self):
+        gen = AlternatingSnakePathGenerator("x", max_corner_radius=None)
+        path = list(gen.generate_path(_CR_GRID, _CR_X_LIM, _CR_Y_LIM))
+        assert not _all_path_points_in_grid(path, _CR_GRID), (
+            "alternating snake with auto radius should produce arc points"
+        )
+
+    # --- SpiralPathGenerator ---
+
+    def test_spiral_default_generates_arc_points(self):
+        gen = SpiralPathGenerator("x", max_corner_radius=None)
+        path = list(gen.generate_path(_CR_GRID, _CR_X_LIM, _CR_Y_LIM))
+        assert len(path) > len(_CR_GRID), "spiral auto radius should generate overshoot points"
+        assert not _all_path_points_in_grid(path, _CR_GRID), "spiral arcs should produce off-grid points"
+
+    def test_spiral_zero_radius_no_arcs(self):
+        gen = SpiralPathGenerator("x", max_corner_radius=0.0)
+        path = list(gen.generate_path(_CR_GRID, _CR_X_LIM, _CR_Y_LIM))
+        assert _all_path_points_in_grid(path, _CR_GRID), "spiral with radius=0 should yield only grid points"
+
+    def test_spiral_positive_cap_limits_overshoot(self):
+        # spiral auto-radius = 1.0; cap at 0.5 should produce smaller arcs
+        cap = 0.5
+        gen_capped = SpiralPathGenerator("x", max_corner_radius=cap)
+        gen_auto = SpiralPathGenerator("x", max_corner_radius=None)
+        path_capped = list(gen_capped.generate_path(_CR_GRID, _CR_X_LIM, _CR_Y_LIM))
+        path_auto = list(gen_auto.generate_path(_CR_GRID, _CR_X_LIM, _CR_Y_LIM))
+        # Both should have more points than the grid (arcs exist)
+        assert len(path_capped) > len(_CR_GRID)
+        # Capped path should deviate less from the grid than auto
+        grid_arr = np.asarray(_CR_GRID)
+        max_dev_capped = max(float(np.min(np.linalg.norm(grid_arr - np.asarray(pt), axis=1))) for pt in path_capped)
+        max_dev_auto = max(float(np.min(np.linalg.norm(grid_arr - np.asarray(pt), axis=1))) for pt in path_auto)
+        assert max_dev_capped < max_dev_auto, (
+            f"capped deviation {max_dev_capped:.3f} should be less than auto {max_dev_auto:.3f}"
+        )
+
+
+class TestApplyCornerRadiusCap:
+    """Unit tests for the apply_corner_radius_cap shared helper."""
+
+    def test_none_returns_auto(self):
+        assert apply_corner_radius_cap(3.5, None) == 3.5
+
+    def test_zero_disables_arcs(self):
+        assert apply_corner_radius_cap(3.5, 0.0) == 0.0
+
+    def test_positive_cap_clamps(self):
+        assert apply_corner_radius_cap(3.5, 2.0) == 2.0
+
+    def test_positive_cap_does_not_upsize(self):
+        # cap larger than auto → auto wins
+        assert apply_corner_radius_cap(1.0, 5.0) == 1.0
+
+    def test_negative_auto_clamped_to_zero(self):
+        # auto can transiently go negative (e.g. mesh touches axis limit)
+        assert apply_corner_radius_cap(-0.1, None) == 0.0
+
+    def test_negative_auto_with_cap(self):
+        assert apply_corner_radius_cap(-1.0, 2.0) == 0.0

--- a/tests/macros/bed_mesh/test_scan_mesh.py
+++ b/tests/macros/bed_mesh/test_scan_mesh.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
 from dataclasses import dataclass, replace
-from typing import TYPE_CHECKING, final
+from typing import TYPE_CHECKING, cast, final
 
 import numpy as np
 import pytest
@@ -235,6 +235,81 @@ class TestBedMeshIntegration:
         # Check that all expected nozzle positions were visited
         missing = expected_nozzle_positions - actual_move_positions
         assert not missing, f"Missing expected nozzle moves: {missing}"
+
+    def test_max_corner_radius_zero_macro_override_disables_arc_moves(
+        self,
+        mocker: MockerFixture,
+        bed_mesh_macro: BedMeshCalibrateMacro,
+        probe_offset: Position,
+        params: MockParams,
+        session: Mock,
+        toolhead: MockToolhead,
+    ):
+        """Test that MAX_CORNER_RADIUS=0 is wired through BED_MESH_CALIBRATE and removes off-grid arc moves."""
+        expected_probe_positions = [(float(10 + 20 * x), float(10 + 20 * y)) for x in range(5) for y in range(5)]
+        heights = [1.5 + 0.1 * i for i in range(len(expected_probe_positions))]
+        mock_samples = self.create_samples_at_probe_positions(expected_probe_positions, heights, probe_offset)
+        session.get_items = mocker.Mock(return_value=mock_samples)
+
+        params.params = {"METHOD": "scan", "MAX_CORNER_RADIUS": "0"}
+        bed_mesh_macro.run(params)
+
+        expected_nozzle_positions = {
+            (round(px - probe_offset.x, 2), round(py - probe_offset.y, 2)) for (px, py) in expected_probe_positions
+        }
+        actual_move_positions = {(round(x, 2), round(y, 2)) for x, y in toolhead.moves}
+        non_scan_moves = {(0.0, 0.0)}
+
+        extra_moves = actual_move_positions - expected_nozzle_positions - non_scan_moves
+        assert not extra_moves, f"MAX_CORNER_RADIUS=0 generated off-grid arc moves: {extra_moves}"
+
+    def test_max_corner_radius_auto_macro_override_enables_arc_moves_when_config_disables_them(
+        self,
+        mocker: MockerFixture,
+        probe: Probe,
+        toolhead: MockToolhead,
+        adapter: BedMeshAdapter,
+        mesh_config: BedMeshCalibrateConfiguration,
+        probe_offset: Position,
+        params: MockParams,
+        session: Mock,
+    ):
+        """Test that MAX_CORNER_RADIUS=AUTO overrides a configured zero radius back to automatic arcs."""
+        expected_probe_positions = [(float(10 + 20 * x), float(10 + 20 * y)) for x in range(5) for y in range(5)]
+        heights = [1.5 + 0.1 * i for i in range(len(expected_probe_positions))]
+        mock_samples = self.create_samples_at_probe_positions(expected_probe_positions, heights, probe_offset)
+        session.get_items = mocker.Mock(return_value=mock_samples)
+        macro = BedMeshCalibrateMacro(
+            probe,
+            cast("Toolhead", cast("object", toolhead)),
+            adapter,
+            None,
+            InlineTaskExecutor(),
+            replace(mesh_config, max_corner_radius=0.0),
+        )
+
+        params.params = {"METHOD": "scan", "MAX_CORNER_RADIUS": "AUTO"}
+        macro.run(params)
+
+        expected_nozzle_positions = {
+            (round(px - probe_offset.x, 2), round(py - probe_offset.y, 2)) for (px, py) in expected_probe_positions
+        }
+        actual_move_positions = {(round(x, 2), round(y, 2)) for x, y in toolhead.moves}
+        non_scan_moves = {(0.0, 0.0)}
+
+        extra_moves = actual_move_positions - expected_nozzle_positions - non_scan_moves
+        assert extra_moves, "MAX_CORNER_RADIUS=AUTO did not restore automatic off-grid arc moves"
+
+    def test_max_corner_radius_negative_macro_override_is_rejected(
+        self,
+        bed_mesh_macro: BedMeshCalibrateMacro,
+        params: MockParams,
+    ):
+        """Test that MAX_CORNER_RADIUS rejects negative values."""
+        params.params = {"METHOD": "scan", "MAX_CORNER_RADIUS": "-1"}
+
+        with pytest.raises(ValueError):
+            bed_mesh_macro.run(params)
 
     def test_adaptive_mesh_boundary_and_coordinate_transformation(
         self,

--- a/tests/mocks/config.py
+++ b/tests/mocks/config.py
@@ -37,6 +37,7 @@ default_scan_config = ScanConfig(
     mesh_direction=MeshDirection.X,
     mesh_height=4.0,
     mesh_path=MeshPath.SNAKE,
+    mesh_max_corner_radius=None,
 )
 default_touch_config = TouchConfig(
     samples=5,


### PR DESCRIPTION
## Summary
Adds configurable scan-mesh max corner radius control so users can keep the current automatic smoothing behavior, disable smoothing arcs entirely, or cap corner overshoot for constrained machines.

Wires `[cartographer scan] mesh_max_corner_radius` and `BED_MESH_CALIBRATE MAX_CORNER_RADIUS` through snake, alternating snake, and spiral path generation. Random paths accept the constructor argument but ignore it.

Also updates `scripts/plot_path.py` so paths can be rendered for a single static grid, parameterized by max corner radius, and saved to an output file.

## Decisions & callouts
- Omitting `mesh_max_corner_radius` or setting it to `auto` preserves existing auto-radius behavior.
- `MAX_CORNER_RADIUS=AUTO` can force automatic behavior for a single macro call.
- `MAX_CORNER_RADIUS=0` disables generated arc moves for users who do not want corner overshoot.
- Positive values cap the computed auto radius instead of replacing safety limits.
- Negative values are rejected.
- `scripts/plot_path.py` is intentionally simple local visualization tooling: one static grid, optional output file, optional interactive display.

## Install

```bash
~/klippy-env/bin/pip install --no-cache-dir --force-reinstall "git+https://github.com/Cartographer3D/cartographer3d-plugin.git@feat/mesh-corner-radius"
sudo systemctl restart klipper
```

To revert to the latest stable release:

```bash
~/klippy-env/bin/pip install --no-cache-dir --force-reinstall cartographer3d-plugin
sudo systemctl restart klipper
```