### PR TITLE
chore: add GitHub PR and issue templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -1,0 +1,80 @@
+name: Bug report
+description: Report a problem with the Cartographer3D plugin.
+labels: ["fix"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Use this form for reproducible Cartographer3D plugin bugs, errors, or regressions.
+
+        If you need setup help, calibration advice, or printer-specific troubleshooting and are not sure this is a plugin bug, please start with the documentation, Discord, or contact links on the issue chooser.
+
+  - type: dropdown
+    id: firmware
+    attributes:
+      label: Firmware target
+      description: Which host firmware are you running?
+      options:
+        - Klipper (mainline)
+        - Kalico
+        - SimpleAF
+        - Other / Unknown
+    validations:
+      required: true
+
+  - type: input
+    id: firmware_version
+    attributes:
+      label: Firmware version
+      description: The Klipper, Kalico, or SimpleAF version/commit you are running.
+      placeholder: "e.g. v0.12.0-123-gabcdef, commit SHA, or release version"
+    validations:
+      required: true
+
+  - type: input
+    id: plugin_version
+    attributes:
+      label: Plugin version
+      placeholder: "e.g. 1.2.3 or git SHA"
+    validations:
+      required: true
+
+  - type: textarea
+    id: description
+    attributes:
+      label: What happened?
+      description: A clear description of the bug — what went wrong?
+    validations:
+      required: true
+
+  - type: textarea
+    id: expected
+    attributes:
+      label: What did you expect to happen?
+    validations:
+      required: true
+
+  - type: textarea
+    id: steps
+    attributes:
+      label: Steps to reproduce
+      placeholder: |
+        1. Configure ...
+        2. Run macro ...
+        3. See error ...
+    validations:
+      required: true
+
+  - type: textarea
+    id: config
+    attributes:
+      label: Relevant printer.cfg / cartographer config
+      description: Paste the `[cartographer]` section and any related blocks. Remove sensitive values (e.g. IPs, serial numbers).
+      render: ini
+
+  - type: textarea
+    id: logs
+    attributes:
+      label: Klipper log / error output
+      description: Paste relevant lines from `klippy.log` or the console.
+      render: text

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,11 @@
+blank_issues_enabled: false
+contact_links:
+  - name: Documentation
+    url: https://docs.cartographer3d.com/
+    about: Configuration guides, calibration walkthroughs, and troubleshooting.
+  - name: Discord community
+    url: https://discord.gg/EFSwpureHz
+    about: For setup help, calibration advice, and printer-specific troubleshooting.
+  - name: Contact Cartographer3D
+    url: https://cartographer3d.com/pages/contact
+    about: For general questions and community support, contact Cartographer3D directly.

--- a/.github/ISSUE_TEMPLATE/feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yml
@@ -1,0 +1,36 @@
+name: Feature request
+description: Suggest a new feature or improvement.
+labels: ["enhancement"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Before submitting, check [open issues](../../issues) and the [documentation](https://docs.cartographer3d.com/) to see if this is already tracked or covered.
+
+  - type: textarea
+    id: problem
+    attributes:
+      label: Problem / motivation
+      description: What problem does this solve? What are you trying to do today that you can't?
+    validations:
+      required: true
+
+  - type: textarea
+    id: solution
+    attributes:
+      label: Proposed solution
+      description: Describe the behaviour you'd like to see. G-code examples or config snippets are welcome.
+    validations:
+      required: true
+
+  - type: textarea
+    id: alternatives
+    attributes:
+      label: Alternatives considered
+      description: Any other approaches you've thought about, and why they fall short?
+
+  - type: textarea
+    id: context
+    attributes:
+      label: Additional context
+      description: Links, examples, screenshots, or prior discussion that would help explain the request.

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,35 @@
+<!-- PR title: use `fix:`, `feat:`, `chore:`, or `perf:` so auto-labeling and release notes work. Use `!` for breaking changes. -->
+
+## Reason / issue reference
+
+<!-- Why is this change needed? Link or close the issue if there is one. -->
+
+Closes #
+
+## Functional changes
+
+<!-- What user-facing behavior changed? Focus on what users can do now, what behaves differently, or what problem is resolved. Avoid summarizing code changes; reviewers can see implementation details in the diff. -->
+
+## Decisions and callouts
+
+<!-- Design choices, tradeoffs, compatibility concerns, or specific areas where reviewer attention would help.
+Remove this section if there is nothing to call out. -->
+
+## Manual testing
+
+<!-- Optional. Include hardware/firmware target, commands/macros run, or observed results.
+Remove this section if not applicable. -->
+
+## Install
+
+```bash
+~/klippy-env/bin/pip install --no-cache-dir --force-reinstall "git+https://github.com/Cartographer3D/cartographer3d-plugin.git@BRANCH_OR_SHA"
+sudo systemctl restart klipper
+```
+
+To revert to the latest stable release:
+
+```bash
+~/klippy-env/bin/pip install --no-cache-dir --force-reinstall cartographer3d-plugin
+sudo systemctl restart klipper
+```

--- a/.github/auto-label-config.json
+++ b/.github/auto-label-config.json
@@ -3,7 +3,7 @@
     "fix",
     "enhancement",
     "chore",
-    "breaking change",
+    "breaking-change",
     "ignore-for-release",
     "performance"
   ],
@@ -15,5 +15,6 @@
   },
   "releaseRelevantPaths": ["^src/", "^uv\\.lock$"],
   "breakingChangeIndicator": "!",
+  "breakingChangeLabel": "breaking-change",
   "ignoreForReleaseLabel": "ignore-for-release"
 }

--- a/.github/scripts/auto-label-pr.js
+++ b/.github/scripts/auto-label-pr.js
@@ -20,7 +20,7 @@ function getLabelsFromTitle(title) {
 
   // Check for breaking change
   if (normalizedTitle.includes(config.breakingChangeIndicator)) {
-    labels.push("breaking change");
+    labels.push(config.breakingChangeLabel);
   }
 
   return labels;


### PR DESCRIPTION
## Reason / issue reference

The repository did not have GitHub PR or issue templates, so contributors had no structured way to provide the context maintainers usually need for review, bugs, and feature requests.

## Functional changes

- Adds a slim PR template focused on reason, functional impact, decisions/callouts, manual testing, and install instructions.
- Adds a bug report form that collects host firmware target/version, plugin version, reproduction steps, config, and logs.
- Adds a feature request form focused on user problem, proposed behavior, alternatives, and context.
- Routes non-issue support toward documentation, Discord, and the Cartographer3D contact page.
- Updates PR auto-labeling to use the existing `breaking-change` release-note label.

## Decisions and callouts

- Kept CI and code-quality checklists out of the PR template because those are already automated.
- Kept PR title guidance as an HTML comment so it does not add visible template noise.
- Made the install section visible boilerplate, matching the format used in recent project PRs.
- Removed implementation-detail prompts from the feature request form, such as scipy and target compatibility.
- Preserved `.github/release.yml`'s existing `breaking-change` label and changed auto-labeling to match it.

## Manual testing

No manual testing; GitHub metadata-only change.

## Install

No install needed; GitHub metadata-only change.