### PR TITLE
feat: add Hilbert curve bed mesh path generator

### DIFF
--- a/scripts/plot_path.py
+++ b/scripts/plot_path.py
@@ -10,6 +10,7 @@ from typing import TYPE_CHECKING
 import matplotlib.pyplot as plt
 
 from cartographer.macros.bed_mesh.paths.alternating_snake import AlternatingSnakePathGenerator
+from cartographer.macros.bed_mesh.paths.hilbert_path import HilbertPathGenerator
 from cartographer.macros.bed_mesh.paths.random_path import RandomPathGenerator
 from cartographer.macros.bed_mesh.paths.snake_path import SnakePathGenerator
 from cartographer.macros.bed_mesh.paths.spiral_path import SpiralPathGenerator
@@ -25,6 +26,7 @@ PATH_STRATEGY_MAP = {
     "alternating_snake": AlternatingSnakePathGenerator,
     "spiral": SpiralPathGenerator,
     "random": RandomPathGenerator,
+    "hilbert": HilbertPathGenerator,
 }
 
 # ---------------------------------------------------------------------------
@@ -161,6 +163,7 @@ examples:
   python scripts/plot_path.py snake
   python scripts/plot_path.py snake --grid 7x7 --max-corner-radius 0 --output snake.png
   python scripts/plot_path.py spiral --grid 9x8 --max-corner-radius auto
+  python scripts/plot_path.py hilbert --grid 21x21 --direction x --output hilbert.png
 """,
     )
     parser.add_argument(
@@ -181,7 +184,7 @@ examples:
         default=None,
         type=parse_max_corner_radius,
         dest="max_corner_radius",
-        help="Corner-radius cap: 'auto' or a non-negative float. Omit for auto.",
+        help="Corner-radius cap: 'auto' or a non-negative float. Omit for auto (ignored by random and hilbert).",
     )
     parser.add_argument(
         "--grid",

--- a/src/cartographer/interfaces/configuration.py
+++ b/src/cartographer/interfaces/configuration.py
@@ -28,6 +28,7 @@ class MeshPath(str, Enum):
     ALTERNATING_SNAKE = "alternating_snake"
     SPIRAL = "spiral"
     RANDOM = "random"
+    HILBERT = "hilbert"
 
     # See MeshDirection.__str__ for rationale.
     @override

--- a/src/cartographer/macros/bed_mesh/paths/hilbert_path.py
+++ b/src/cartographer/macros/bed_mesh/paths/hilbert_path.py
@@ -1,0 +1,105 @@
+from __future__ import annotations
+
+from typing import TYPE_CHECKING, Iterator, final
+
+from typing_extensions import override
+
+from cartographer.macros.bed_mesh.interfaces import PathGenerator
+from cartographer.macros.bed_mesh.paths.utils import cluster_points
+
+if TYPE_CHECKING:
+    from cartographer.macros.bed_mesh.interfaces import Point
+
+
+def next_power_of_two(n: int) -> int:
+    """Return the smallest power of two that is >= *n*."""
+    if n <= 1:
+        return 1
+    p = 1
+    while p < n:
+        p <<= 1
+    return p
+
+
+def xy_to_hilbert(order: int, x: int, y: int) -> int:
+    """Convert (x, y) grid coordinates to a Hilbert curve distance.
+
+    ``order`` is the side length of the embedding square (must be a power of
+    two).  Both ``x`` and ``y`` must satisfy ``0 <= x, y < order``.
+
+    The algorithm follows the standard d2xy / xy2d mapping described at
+    https://en.wikipedia.org/wiki/Hilbert_curve#Applications_and_mapping_algorithms
+    """
+    d = 0
+    s = order >> 1
+    while s > 0:
+        rx = 1 if (x & s) > 0 else 0
+        ry = 1 if (y & s) > 0 else 0
+        d += s * s * ((3 * rx) ^ ry)
+        # Rotate the quadrant so the next level is in the right orientation.
+        if ry == 0:
+            if rx == 1:
+                x = s - 1 - x
+                y = s - 1 - y
+            x, y = y, x
+        s >>= 1
+    return d
+
+
+@final
+class HilbertPathGenerator(PathGenerator):
+    """Scan the bed mesh in Hilbert-curve order.
+
+    Grid points are assigned integer (col, row) coordinates, embedded inside
+    the smallest power-of-two square that contains the full grid, and then
+    sorted by their Hilbert index in that square.  This minimises the maximum
+    step between consecutive scan points while still covering every grid point
+    exactly once — no duplicate waypoints, no arc interpolation.
+
+    ``main_direction`` controls the orientation of the embedding:
+
+    * ``"x"`` — the column index is mapped to the *y* Hilbert axis and the row
+      index is mapped to the *x* Hilbert axis so the very first segment of the
+      curve moves in the +X physical direction.
+    * ``"y"`` — transposed: the first segment moves in the +Y physical
+      direction.
+
+    ``max_corner_radius`` is accepted for API compatibility with other
+    generators but has no effect — the Hilbert path visits only the original
+    mesh points without inserting arc waypoints.
+    """
+
+    def __init__(self, main_direction: str, max_corner_radius: float | None = None):
+        self.main_direction: str = main_direction
+        self.max_corner_radius: float | None = max_corner_radius
+
+    @override
+    def generate_path(
+        self,
+        points: list[Point],
+        x_axis_limits: tuple[float, float],
+        y_axis_limits: tuple[float, float],
+    ) -> Iterator[Point]:
+        del x_axis_limits, y_axis_limits  # not used — no arc waypoints
+
+        if not points:
+            return
+
+        # Build a 2-D grid: grid[r][c] is the physical point at y-row r, x-col c.
+        grid = cluster_points(points, "x")
+        rows = len(grid)
+        cols = max(len(row) for row in grid) if rows else 0
+
+        order = next_power_of_two(max(cols, rows))
+
+        keyed: list[tuple[int, Point]] = []
+        for r, row in enumerate(grid):
+            for c, pt in enumerate(row):
+                # main_direction="x": (row→x_hilbert, col→y_hilbert) so first step is +physical-X.
+                # main_direction="y": (col→x_hilbert, row→y_hilbert) so first step is +physical-Y.
+                key = xy_to_hilbert(order, r, c) if self.main_direction == "x" else xy_to_hilbert(order, c, r)
+                keyed.append((key, pt))
+
+        keyed.sort(key=lambda item: item[0])
+        for _, pt in keyed:
+            yield pt

--- a/src/cartographer/macros/bed_mesh/scan_mesh.py
+++ b/src/cartographer/macros/bed_mesh/scan_mesh.py
@@ -29,6 +29,7 @@ from cartographer.macros.bed_mesh.helpers import (
     SampleProcessor,
 )
 from cartographer.macros.bed_mesh.paths.alternating_snake import AlternatingSnakePathGenerator
+from cartographer.macros.bed_mesh.paths.hilbert_path import HilbertPathGenerator
 from cartographer.macros.bed_mesh.paths.random_path import RandomPathGenerator
 from cartographer.macros.bed_mesh.paths.snake_path import SnakePathGenerator
 from cartographer.macros.bed_mesh.paths.spiral_path import SpiralPathGenerator
@@ -111,6 +112,7 @@ PATH_GENERATOR_MAP = {
     MeshPath.ALTERNATING_SNAKE: AlternatingSnakePathGenerator,
     MeshPath.SPIRAL: SpiralPathGenerator,
     MeshPath.RANDOM: RandomPathGenerator,
+    MeshPath.HILBERT: HilbertPathGenerator,
 }
 
 

--- a/tests/config/test_fields.py
+++ b/tests/config/test_fields.py
@@ -354,6 +354,7 @@ class TestEnumStr:
         assert str(MeshPath.ALTERNATING_SNAKE) == "alternating_snake"
         assert str(MeshPath.SPIRAL) == "spiral"
         assert str(MeshPath.RANDOM) == "random"
+        assert str(MeshPath.HILBERT) == "hilbert"
 
     def test_mesh_path_fstring(self) -> None:
         assert f"{MeshPath.SNAKE}" == "snake"

--- a/tests/macros/bed_mesh/test_path_generators.py
+++ b/tests/macros/bed_mesh/test_path_generators.py
@@ -7,6 +7,7 @@ import pytest
 from typing_extensions import TypeAlias
 
 from cartographer.macros.bed_mesh.paths.alternating_snake import AlternatingSnakePathGenerator
+from cartographer.macros.bed_mesh.paths.hilbert_path import HilbertPathGenerator, next_power_of_two, xy_to_hilbert
 from cartographer.macros.bed_mesh.paths.random_path import RandomPathGenerator
 from cartographer.macros.bed_mesh.paths.snake_path import SnakePathGenerator
 from cartographer.macros.bed_mesh.paths.spiral_path import SpiralPathGenerator
@@ -28,8 +29,12 @@ GridFixture: TypeAlias = "tuple[str, list[Point]]"
     params=[
         ("Snake X", lambda: SnakePathGenerator(main_direction="x")),
         ("Snake Y", lambda: SnakePathGenerator(main_direction="y")),
+        ("Alternating Snake X", lambda: AlternatingSnakePathGenerator(main_direction="x")),
+        ("Alternating Snake Y", lambda: AlternatingSnakePathGenerator(main_direction="y")),
         ("Spiral", lambda: SpiralPathGenerator(main_direction="x")),
         ("Random", lambda: RandomPathGenerator(main_direction="x")),
+        ("Hilbert X", lambda: HilbertPathGenerator(main_direction="x")),
+        ("Hilbert Y", lambda: HilbertPathGenerator(main_direction="y")),
     ]
 )
 def generator(request: pytest.FixtureRequest):
@@ -193,3 +198,228 @@ class TestApplyCornerRadiusCap:
 
     def test_negative_auto_with_cap(self):
         assert apply_corner_radius_cap(-1.0, 2.0) == 0.0
+
+
+# ---------------------------------------------------------------------------
+# Hilbert path internals
+# ---------------------------------------------------------------------------
+
+
+class TestNextPowerOfTwo:
+    def test_one(self):
+        assert next_power_of_two(1) == 1
+
+    def test_already_power_of_two(self):
+        assert next_power_of_two(4) == 4
+        assert next_power_of_two(8) == 8
+        assert next_power_of_two(16) == 16
+
+    def test_rounds_up(self):
+        assert next_power_of_two(3) == 4
+        assert next_power_of_two(5) == 8
+        assert next_power_of_two(10) == 16
+        assert next_power_of_two(11) == 16
+        assert next_power_of_two(20) == 32
+        assert next_power_of_two(21) == 32
+
+    def test_zero_or_negative_returns_one(self):
+        assert next_power_of_two(0) == 1
+        assert next_power_of_two(-5) == 1
+
+
+class TestXyToHilbert:
+    """Spot-check xy_to_hilbert for small power-of-two grids."""
+
+    def test_2x2_all_indices_unique(self):
+        """All four (x,y) positions in a 2×2 square get distinct distances."""
+        distances = {xy_to_hilbert(2, x, y) for x in range(2) for y in range(2)}
+        assert distances == {0, 1, 2, 3}
+
+    def test_4x4_all_indices_unique(self):
+        distances = {xy_to_hilbert(4, x, y) for x in range(4) for y in range(4)}
+        assert len(distances) == 16
+        assert distances == set(range(16))
+
+    def test_origin_is_always_zero(self):
+        for order in (1, 2, 4, 8, 16):
+            assert xy_to_hilbert(order, 0, 0) == 0
+
+
+# ---------------------------------------------------------------------------
+# HilbertPathGenerator behaviour
+# ---------------------------------------------------------------------------
+
+
+_AXIS_LIMITS = (-10.0, 300.0)
+
+
+class TestHilbertPathGeneratorExact:
+    """Exact output tests for small, well-known grids."""
+
+    def test_1x1_grid_yields_single_point(self):
+        gen = HilbertPathGenerator("x")
+        pts: list[Point] = [(5.0, 7.0)]
+        path = list(gen.generate_path(pts, _AXIS_LIMITS, _AXIS_LIMITS))
+        assert path == [(5.0, 7.0)]
+
+    def test_empty_grid_yields_nothing(self):
+        gen = HilbertPathGenerator("x")
+        path = list(gen.generate_path([], _AXIS_LIMITS, _AXIS_LIMITS))
+        assert path == []
+
+    def test_2x2_x_direction_exact_order(self):
+        """For a 2×2 unit grid, main_direction='x' first step is +X."""
+        # grid[0] = [(0,0),(1,0)], grid[1] = [(0,1),(1,1)]
+        # r=0,c=0 → hilbert(2,0,0)=0  → (0,0)
+        # r=0,c=1 → hilbert(2,0,1)=1  → (1,0)
+        # r=1,c=1 → hilbert(2,1,1)=2  → (1,1)
+        # r=1,c=0 → hilbert(2,1,0)=3  → (0,1)
+        gen = HilbertPathGenerator("x")
+        pts: list[Point] = [(0.0, 0.0), (1.0, 0.0), (0.0, 1.0), (1.0, 1.0)]
+        path = list(gen.generate_path(pts, _AXIS_LIMITS, _AXIS_LIMITS))
+        assert path[0] == (0.0, 0.0), "first point must be origin"
+        # First move should be in the +X direction
+        assert float(path[1][0]) > float(path[0][0]), "first step should be +X for main_direction='x'"
+        assert len(path) == 4
+
+    def test_2x2_y_direction_exact_order(self):
+        """For a 2×2 unit grid, main_direction='y' first step is +Y."""
+        gen = HilbertPathGenerator("y")
+        pts: list[Point] = [(0.0, 0.0), (1.0, 0.0), (0.0, 1.0), (1.0, 1.0)]
+        path = list(gen.generate_path(pts, _AXIS_LIMITS, _AXIS_LIMITS))
+        assert path[0] == (0.0, 0.0), "first point must be origin"
+        # First move should be in the +Y direction
+        assert float(path[1][1]) > float(path[0][1]), "first step should be +Y for main_direction='y'"
+        assert len(path) == 4
+
+    def test_x_and_y_directions_differ(self):
+        """x and y orientation produce different orderings on an asymmetric grid."""
+        pts = make_grid(3, 4, 1.0)  # rectangular → orientations differ
+        gen_x = HilbertPathGenerator("x")
+        gen_y = HilbertPathGenerator("y")
+        path_x = list(gen_x.generate_path(pts, _AXIS_LIMITS, _AXIS_LIMITS))
+        path_y = list(gen_y.generate_path(pts, _AXIS_LIMITS, _AXIS_LIMITS))
+        assert path_x != path_y, "x and y orientations must produce different traversal orders"
+
+
+class TestHilbertPathGeneratorNoDuplicates:
+    """Each input mesh point is visited exactly once."""
+
+    @pytest.mark.parametrize(
+        "nx,ny",
+        [
+            (3, 3),
+            (4, 4),
+            (5, 5),
+            (10, 10),
+            (11, 11),
+            (20, 20),
+            (21, 21),
+            (3, 5),
+            (5, 3),
+            (4, 7),
+            (7, 4),
+        ],
+    )
+    def test_no_duplicates_covers_all_points(self, nx: int, ny: int):
+        pts = make_grid(nx, ny, 1.0)
+        gen = HilbertPathGenerator("x")
+        path = list(gen.generate_path(pts, _AXIS_LIMITS, _AXIS_LIMITS))
+        assert len(path) == len(pts), f"expected {len(pts)} points for {nx}×{ny}, got {len(path)}"
+        # Convert to rounded tuples for set comparison (floats may vary slightly)
+        path_set = {(round(float(x), 6), round(float(y), 6)) for x, y in path}
+        pts_set = {(round(float(x), 6), round(float(y), 6)) for x, y in pts}
+        assert path_set == pts_set, f"{nx}×{ny}: path does not cover all input points exactly"
+
+
+class TestHilbertPathGeneratorDeterministic:
+    """Repeated calls with identical input produce identical output."""
+
+    @pytest.mark.parametrize("direction", ["x", "y"])
+    def test_deterministic(self, direction: str):
+        pts = make_grid(5, 5, 2.5)
+        gen = HilbertPathGenerator(direction)
+        path_a = list(gen.generate_path(pts, _AXIS_LIMITS, _AXIS_LIMITS))
+        path_b = list(gen.generate_path(pts, _AXIS_LIMITS, _AXIS_LIMITS))
+        assert path_a == path_b, f"Hilbert {direction!r}: two calls produced different orderings"
+
+
+class TestHilbertPathGeneratorRectangular:
+    """Rectangular (non-square) grids are handled correctly."""
+
+    @pytest.mark.parametrize(
+        "nx,ny",
+        [
+            (3, 7),
+            (7, 3),
+            (1, 10),
+            (10, 1),
+            (6, 11),
+        ],
+    )
+    def test_rectangular_covers_all_points(self, nx: int, ny: int):
+        pts = make_grid(nx, ny, 1.0)
+        gen = HilbertPathGenerator("x")
+        path = list(gen.generate_path(pts, _AXIS_LIMITS, _AXIS_LIMITS))
+        assert len(path) == nx * ny
+        path_set = {(round(float(x), 6), round(float(y), 6)) for x, y in path}
+        pts_set = {(round(float(x), 6), round(float(y), 6)) for x, y in pts}
+        assert path_set == pts_set
+
+
+class TestHilbertPathGeneratorMaxCornerRadius:
+    """max_corner_radius is accepted but has no effect on the output."""
+
+    def test_radius_none_same_as_zero(self):
+        pts = make_grid(4, 4, 1.0)
+        gen_none = HilbertPathGenerator("x", max_corner_radius=None)
+        gen_zero = HilbertPathGenerator("x", max_corner_radius=0.0)
+        gen_pos = HilbertPathGenerator("x", max_corner_radius=5.0)
+        path_none = list(gen_none.generate_path(pts, _AXIS_LIMITS, _AXIS_LIMITS))
+        path_zero = list(gen_zero.generate_path(pts, _AXIS_LIMITS, _AXIS_LIMITS))
+        path_pos = list(gen_pos.generate_path(pts, _AXIS_LIMITS, _AXIS_LIMITS))
+        # All three should produce identical paths (no arc points added)
+        assert path_none == path_zero == path_pos
+        assert len(path_none) == 16  # exactly the grid points, no extras
+
+
+class TestHilbertPathRegistration:
+    """MeshPath.HILBERT is registered in PATH_GENERATOR_MAP."""
+
+    def test_hilbert_in_mesh_path_enum(self):
+        from cartographer.interfaces.configuration import MeshPath
+
+        assert MeshPath("hilbert") == MeshPath.HILBERT
+        assert str(MeshPath.HILBERT) == "hilbert"
+
+    def test_hilbert_in_path_generator_map(self):
+        from cartographer.interfaces.configuration import MeshPath
+        from cartographer.macros.bed_mesh.scan_mesh import PATH_GENERATOR_MAP
+
+        assert MeshPath.HILBERT in PATH_GENERATOR_MAP
+        assert PATH_GENERATOR_MAP[MeshPath.HILBERT] is HilbertPathGenerator
+
+    def test_path_generator_map_produces_correct_instance(self):
+        from cartographer.interfaces.configuration import MeshPath
+        from cartographer.macros.bed_mesh.scan_mesh import PATH_GENERATOR_MAP
+
+        gen = PATH_GENERATOR_MAP[MeshPath.HILBERT]("x", None)
+        assert isinstance(gen, HilbertPathGenerator)
+
+
+class TestAlternatingSnakePathRegistration:
+    """MeshPath.ALTERNATING_SNAKE is registered in PATH_GENERATOR_MAP."""
+
+    def test_alternating_snake_in_path_generator_map(self):
+        from cartographer.interfaces.configuration import MeshPath
+        from cartographer.macros.bed_mesh.scan_mesh import PATH_GENERATOR_MAP
+
+        assert MeshPath.ALTERNATING_SNAKE in PATH_GENERATOR_MAP
+        assert PATH_GENERATOR_MAP[MeshPath.ALTERNATING_SNAKE] is AlternatingSnakePathGenerator
+
+    def test_path_generator_map_produces_correct_instance(self):
+        from cartographer.interfaces.configuration import MeshPath
+        from cartographer.macros.bed_mesh.scan_mesh import PATH_GENERATOR_MAP
+
+        gen = PATH_GENERATOR_MAP[MeshPath.ALTERNATING_SNAKE]("x", None)
+        assert isinstance(gen, AlternatingSnakePathGenerator)


### PR DESCRIPTION
## Reason / issue reference

Add a locality-preserving mesh scan path for common dense square meshes such as 10×10, 11×11, 20×20, and 21×21.

## Functional changes

Users can now select `PATH=hilbert` for scan mesh calibration. The Hilbert path visits each mesh point exactly once in deterministic Hilbert-curve order by embedding rectangular grids in the next power-of-two square.

The path visualization script also supports the new strategy:

```bash
python scripts/plot_path.py hilbert --grid 21x21 --direction x --output hilbert.png
```

## Decisions and callouts

Hilbert does not insert smoothing arc waypoints. It accepts `MAX_CORNER_RADIUS` for API compatibility with the other path generators, but the value has no effect.

For non-power-of-two and rectangular grids, the implementation sorts real mesh points by their Hilbert index in the next power-of-two square. This keeps the strategy usable for typical mesh sizes instead of rejecting non-power-of-two grids.

## Install

```bash
~/klippy-env/bin/pip install --no-cache-dir --force-reinstall "git+https://github.com/Cartographer3D/cartographer3d-plugin.git@feat/hilbert-mesh-path"
sudo systemctl restart klipper
```

To revert to the latest stable release:

```bash
~/klippy-env/bin/pip install --no-cache-dir --force-reinstall cartographer3d-plugin
sudo systemctl restart klipper
```