### PR TITLE
fix: detect klipper-like homing axis API

### DIFF
--- a/src/cartographer/adapters/klipper_like/axis_compat.py
+++ b/src/cartographer/adapters/klipper_like/axis_compat.py
@@ -1,0 +1,21 @@
+from __future__ import annotations
+
+from inspect import Parameter, signature
+from typing import Callable
+
+from typing_extensions import Protocol
+
+
+class _Toolhead(Protocol):
+    @property
+    def set_position(self) -> Callable[..., None]: ...
+
+
+def uses_string_homing_axes(toolhead: _Toolhead) -> bool:
+    """Return whether ``ToolHead.set_position`` expects string homing axes."""
+    try:
+        homing_axes = signature(toolhead.set_position).parameters["homing_axes"]
+    except (TypeError, ValueError, KeyError):
+        return True
+
+    return homing_axes.default is Parameter.empty or isinstance(homing_axes.default, str)

--- a/src/cartographer/adapters/klipper_like/toolhead.py
+++ b/src/cartographer/adapters/klipper_like/toolhead.py
@@ -9,6 +9,7 @@ from extras.manual_probe import ManualProbeHelper
 from typing_extensions import override
 
 from cartographer.adapters.klipper.endstop import KlipperEndstop
+from cartographer.adapters.klipper_like.axis_compat import uses_string_homing_axes
 from cartographer.adapters.klipper_like.utils import reraise_from_klipper
 from cartographer.interfaces.printer import Endstop, HomingAxis, Position, TemperatureStatus, Toolhead
 
@@ -68,8 +69,7 @@ class KlipperLikeToolhead(Toolhead, ABC):
     @property
     def _use_str_axes(self) -> bool:
         if self.__use_str_axes is None:
-            kin = self.toolhead.get_kinematics()
-            self.__use_str_axes = not hasattr(kin, "note_z_not_homed")
+            self.__use_str_axes = uses_string_homing_axes(self.toolhead)
         return self.__use_str_axes
 
     def __init__(self, config: ConfigWrapper, mcu: CartographerMcu) -> None:

--- a/tests/klipper_like/test_homing_axis_compat.py
+++ b/tests/klipper_like/test_homing_axis_compat.py
@@ -1,0 +1,21 @@
+from __future__ import annotations
+
+from cartographer.adapters.klipper_like.axis_compat import uses_string_homing_axes
+
+
+class StringAxesToolhead:
+    def set_position(self, newpos: list[float], homing_axes: str = "") -> None:
+        del newpos, homing_axes
+
+
+class IntegerAxesToolhead:
+    def set_position(self, newpos: list[float], homing_axes: tuple[int, ...] = ()) -> None:
+        del newpos, homing_axes
+
+
+def test_detects_string_homing_axes() -> None:
+    assert uses_string_homing_axes(StringAxesToolhead())
+
+
+def test_detects_integer_homing_axes() -> None:
+    assert not uses_string_homing_axes(IntegerAxesToolhead())


### PR DESCRIPTION
## Reason / issue reference

Latest Kalico switched `ToolHead.set_position(..., homing_axes=...)` to the modern Klipper string-axis API while retaining `note_z_not_homed()`. The previous adapter check misclassified that runtime as legacy integer-axis Kalico, so temporary Z homing during touch and scan calibration could fail with `Must home axis first`.

## Functional changes

- Detect the klipper-like homing-axis API from the `ToolHead.set_position` default instead of from `note_z_not_homed()`.
- Preserve support for both string-axis runtimes (`"z"`) and legacy integer-axis runtimes (`(2,)`).
- Add focused regression coverage for both homing-axis API shapes.

## Decisions and callouts

Kept the compatibility check in the shared `klipper_like` adapter layer because both Klipper and Kalico use this path. This avoids adding a Kalico version split to runtime environment detection.

## Install

```bash
~/klippy-env/bin/pip install --no-cache-dir --force-reinstall "git+https://github.com/Cartographer3D/cartographer3d-plugin.git@fix/klipper-like-homing-axis-compat"
sudo systemctl restart klipper
```

To revert to the latest stable release:

```bash
~/klippy-env/bin/pip install --no-cache-dir --force-reinstall cartographer3d-plugin
sudo systemctl restart klipper
```